### PR TITLE
Add dev setup: requirements, example config, pytest and basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@
 
 ## 🛠 使用技術
 
-- Python 3.x
+- Python 3.10+
 - Flask
+- Flask-SQLAlchemy
 - SQLite
 - Bootstrap (Flaskテンプレート内)
 - JavaScript (一部動的UI)
 - JSON（設定ファイル・状態管理）
+- pytest（最低限の自動テスト）
 
 ## 🚀 セットアップ方法
 
@@ -27,16 +29,39 @@ git clone https://github.com/nowdon/shuttlers-match-app.git
 cd shuttlers-match-app
 python -m venv venv
 source venv/bin/activate  # Windows の場合は venv\Scripts\activate
+python -m pip install --upgrade pip
 pip install -r requirements.txt
+cp config.example.json config.json
 ```
 
+`config.json` はローカル環境ごとの設定ファイルです。Git 管理対象外のため、初回セットアップ時は `config.example.json` をコピーして必要に応じて編集してください。
+
 ## ▶️ 起動方法
+
+初回起動前、または参加者DBを作り直したい場合は SQLite のテーブルを作成します。
+
+```bash
+python init_db.py
+```
+
+開発サーバーを起動します。
+
 ```bash
 python app.py
 ```
 
 http://localhost:5001 でアクセスできるようになります。
 (ポートの変更はapp.pyの最終行で指定してください。)
+
+## 🧪 テスト
+
+最低限の pytest 構成を用意しています。ロジックやユーティリティを変更したら、PR作成前に以下を実行してください。
+
+```bash
+pytest
+```
+
+テスト設定は `pytest.ini` に集約しており、`tests/` 配下の `test_*.py` を対象にしています。
 
 ## 🗂 ディレクトリ構成（例）
 ```
@@ -59,6 +84,9 @@ shuttlers-match-app/
 │   ├── participants_template.csv
 │   └── cards/
 │       └── ※カード画像を配置（詳細は下記）
+├── tests/
+│   ├── test_logic.py
+│   └── test_score.py
 ├── utils/
 │   ├── draft_state.py
 │   ├── match_state.py
@@ -66,9 +94,12 @@ shuttlers-match-app/
 │   ├── db_utils.py
 │   ├── state_utils.py
 │   └── score.py
-├── config.json
-├── match_state.json
-├── draft_state.json
+├── config.example.json
+├── config.json          # ローカル設定（Git管理対象外）
+├── match_state.json     # 実行時状態（Git管理対象外）
+├── draft_state.json     # 実行時状態（Git管理対象外）
+├── pytest.ini
+├── requirements.txt
 ├── CHANGELOG.md
 └── README.md
 ```

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,15 @@
+{
+  "paypay_links": {
+    "adults": "https://example.com/pay/adults",
+    "students": "https://example.com/pay/students"
+  },
+  "level_map": {
+    "beginner": 1,
+    "intermediate": 2,
+    "advanced": 3
+  },
+  "gender_weight": {
+    "male": 1.0,
+    "female": 0.9
+  }
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+pythonpath = .
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+addopts = -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+Flask-SQLAlchemy==3.1.1
+qrcode[pil]==7.4.2
+pytest==8.3.3

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from logic import generate_matches
+
+
+def make_player(player_id, games_played=0, active=True):
+    return SimpleNamespace(id=player_id, games_played=games_played, active=active)
+
+
+def test_generate_matches_uses_only_active_players_and_benches_over_capacity():
+    participants = [
+        make_player(1, games_played=0),
+        make_player(2, games_played=0),
+        make_player(3, games_played=1),
+        make_player(4, games_played=1),
+        make_player(5, games_played=2),
+        make_player(6, games_played=0, active=False),
+    ]
+
+    matches, bench = generate_matches(participants, court_count=1)
+
+    matched_ids = {player.id for match in matches for player in match}
+    benched_ids = {player.id for player in bench}
+
+    assert len(matches) == 1
+    assert matched_ids == {1, 2, 3, 4}
+    assert benched_ids == {5}
+    assert 6 not in matched_ids | benched_ids
+
+
+def test_generate_matches_increments_games_played_for_matched_players_only():
+    participants = [make_player(player_id) for player_id in range(1, 6)]
+
+    matches, bench = generate_matches(participants, court_count=1)
+
+    for player in [player for match in matches for player in match]:
+        assert player.games_played == 1
+    for player in bench:
+        assert player.games_played == 0

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from utils.score import calculate_pair_score
+
+
+def test_calculate_pair_score_returns_player_scores_and_total():
+    pair = [
+        SimpleNamespace(name="Alice", level="beginner", gender="female"),
+        SimpleNamespace(name="Bob", level="advanced", gender="male"),
+    ]
+    level_map = {"beginner": 1, "advanced": 3}
+    gender_weight = {"female": 0.9, "male": 1.0}
+
+    result = calculate_pair_score(pair, level_map, gender_weight)
+
+    assert result == {
+        "players": [
+            {"name": "Alice", "score": 0.9},
+            {"name": "Bob", "score": 3.0},
+        ],
+        "total_score": 3.9,
+    }


### PR DESCRIPTION
### Motivation
- Make the repository easier to bootstrap for continued development by documenting setup and providing deterministic dev dependencies and example config. 
- Provide a minimal test harness so core logic and utilities can be validated automatically. 

### Description
- Add `requirements.txt` with pinned dev/runtime dependencies (`Flask`, `Flask-SQLAlchemy`, `qrcode[pil]`, `pytest`).
- Add `config.example.json` and document copying it to `config.json` so environment-specific settings are not committed. 
- Add `pytest.ini` (sets `pythonpath = .` and `tests/` discovery) and two unit tests `tests/test_logic.py` and `tests/test_score.py` that exercise `generate_matches` and `calculate_pair_score` respectively. 
- Update `README.md` with improved setup steps (`python -m pip install --upgrade pip`, `cp config.example.json config.json`), DB initialization (`python init_db.py`), and instructions to run `pytest`.

### Testing
- Ran `pytest`, which executed the new tests and returned `3 passed`.
- Attempted `python -m pip install -r requirements.txt` but package installation could not be verified in this environment due to a package index tunnel error (`Tunnel connection failed: 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202bfd41f88333a875a0442774d419)