### PR TITLE
Fix confirmed matches being cleared when creating draft

### DIFF
--- a/app.py
+++ b/app.py
@@ -287,7 +287,7 @@ def match_form():
     save_draft_state(match_ids, bench_ids)
 
     state['match_active'] = True
-    save_match_state_full(state.get('match_active', True), state.get('matchs', []), state.get('bench', []), state.get('match_count', 0))
+    save_match_state_full(state.get('match_active', True), state.get('matches', []), state.get('bench', []), state.get('match_count', 0))
 
     
     return redirect(url_for('edit_matches', mode=mode))

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -1,0 +1,37 @@
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+
+def test_creating_draft_preserves_confirmed_matches(monkeypatch, tmp_path):
+    config = {
+        "level_map": {},
+        "gender_weight": {},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 6)]
+    confirmed_matches = [[11, 12, 13, 14]]
+    state = {
+        "match_active": True,
+        "matches": confirmed_matches,
+        "bench": [15],
+        "match_count": 3,
+    }
+    saved_state = []
+
+    participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(app_module, "generate_matches", lambda players, courts: ([players[:4]], players[4:]))
+    monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
+    monkeypatch.setattr(app_module, "save_draft_state", lambda matches, bench: None)
+    monkeypatch.setattr(app_module, "save_match_state_full", lambda *args: saved_state.append(args))
+
+    response = app_module.app.test_client().post("/match", data={"court_count": "1"})
+
+    assert response.status_code == 302
+    assert saved_state == [(True, confirmed_matches, [15], 3)]


### PR DESCRIPTION
## 概要

draft作成時に、確定済みの `matches` が空配列で上書きされる不具合を修正します。

## 変更内容

- `app.py` の `state.get('matchs', [])` を正しいキー `state.get('matches', [])` に修正
- draft生成時に既存の確定済みmatchesが `save_match_state_full` へ保持されることを確認するpytestを追加

`draft_state.json` / `match_state.json` の責務や既存仕様には変更を加えていません。

## テスト

- `.venv/bin/python -m pytest tests/test_match_draft.py -q`
- `.venv/bin/python -m pytest -q` (`4 passed`)
- `git diff --check`