### PR TITLE
match_edit 直接アクセス時に共有 draft を保持する

### DIFF
--- a/app.py
+++ b/app.py
@@ -294,9 +294,26 @@ def match_form():
 
 @app.route('/match/edit')
 def edit_matches():
-    # セッションから仮組み合わせを取得
-    match_ids = session.get('draft_matches', [])
-    bench_ids = session.get('draft_bench', [])
+    # セッションに仮組み合わせがなければ共有 draft から復元する
+    if 'draft_matches' in session and 'draft_bench' in session:
+        match_ids = session['draft_matches']
+        bench_ids = session['draft_bench']
+    else:
+        draft = load_draft_state()
+        has_active_draft = (
+            isinstance(draft, dict)
+            and draft.get('draft') is True
+            and isinstance(draft.get('matches'), list)
+            and isinstance(draft.get('bench'), list)
+            and (draft['matches'] or draft['bench'])
+        )
+        if not has_active_draft:
+            return redirect(url_for('match_form'))
+
+        match_ids = draft['matches']
+        bench_ids = draft['bench']
+        session['draft_matches'] = match_ids
+        session['draft_bench'] = bench_ids
 
     participants = {p.id: p for p in Participant.query.all()}
     

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -35,3 +35,113 @@ def test_creating_draft_preserves_confirmed_matches(monkeypatch, tmp_path):
 
     assert response.status_code == 302
     assert saved_state == [(True, confirmed_matches, [15], 3)]
+
+
+def load_test_app(monkeypatch, tmp_path):
+    config = {
+        "level_map": {},
+        "gender_weight": {},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 6)]
+    participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    monkeypatch.setattr(app_module, "calculate_pair_score", lambda pair, *_: {"pair": pair})
+    monkeypatch.setattr(
+        app_module,
+        "render_template",
+        lambda template, **context: json.dumps(
+            {
+                "template": template,
+                "matches": [[player.id for player in group] for group in context.get("matches", [])],
+                "bench": [player.id for player in context.get("bench", [])],
+            }
+        ),
+    )
+    return app_module
+
+
+def test_match_edit_without_session_does_not_clear_shared_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    draft = {
+        "draft": True,
+        "timestamp": "2026-06-12T00:00:00+00:00",
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
+
+    response = app_module.app.test_client().get("/match/edit")
+
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 200
+    assert saved_draft["matches"] == draft["matches"]
+    assert saved_draft["bench"] == draft["bench"]
+
+
+def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    draft = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
+    client = app_module.app.test_client()
+
+    response = client.get("/match/edit")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        "template": "match_edit.html",
+        "matches": draft["matches"],
+        "bench": draft["bench"],
+    }
+    with client.session_transaction() as draft_session:
+        assert draft_session["draft_matches"] == draft["matches"]
+        assert draft_session["draft_bench"] == draft["bench"]
+
+
+def test_match_edit_without_available_draft_redirects_to_match_form(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+
+    response = app_module.app.test_client().get("/match/edit")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match")
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    shared_draft = {
+        "draft": True,
+        "matches": [[5, 4, 3, 2]],
+        "bench": [1],
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
+    client = app_module.app.test_client()
+    with client.session_transaction() as draft_session:
+        draft_session["draft_matches"] = [[1, 2, 3, 4]]
+        draft_session["draft_bench"] = [5]
+
+    response = client.get("/match/edit")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        "template": "match_edit.html",
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert saved_draft["matches"] == [[1, 2, 3, 4]]
+    assert saved_draft["bench"] == [5]


### PR DESCRIPTION
### Motivation

- Accessing `/match/edit` without a session draft could overwrite the shared `draft_state.json` with empty arrays, destroying a draft created from another browser/device. 
- The intent is to prevent that destructive side effect while keeping the existing session-based editing flow intact.

### Description

- Updated `edit_matches()` in `app.py` to use the session `draft_matches`/`draft_bench` when present and otherwise restore a valid shared draft from `draft_state.json` into the session. 
- When no valid shared draft exists and the session contains no draft, the route now redirects to `match_form` instead of saving/overwriting an empty draft. 
- The restoration only occurs if `draft_state.json` contains `"draft": true` and valid `matches`/`bench` arrays, and the code does not overwrite the shared draft with empty arrays during direct access. 
- Added regression tests in `tests/test_match_draft.py` to cover direct access, shared-draft restoration, absence-of-draft redirect, and preserving an existing session draft.

### Testing

- Ran `pytest tests/test_match_draft.py` and the new/updated draft tests all passed (`5 passed`).
- Ran full test suite with `pytest` and all tests passed (`10 passed`).
- Performed a bytecode compile check with `python -m compileall -q app.py tests/test_match_draft.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5af095288333b16cfa842d624b4a)