### PR TITLE
確定時の draft / match state 遷移を整理

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,11 +403,33 @@ def swap_players():
 
     return redirect(url_for('edit_matches', mode=mode))
 
+def has_valid_draft(matches, bench):
+    return (
+        isinstance(matches, list)
+        and isinstance(bench, list)
+        and bool(matches or bench)
+    )
+
+
 @app.route('/match/confirm', methods=['POST'])
 def confirm_match():
+    session_matches = session.get('draft_matches')
+    session_bench = session.get('draft_bench')
 
-    match_ids = session.get('draft_matches', [])
-    bench_ids = session.get('draft_bench', [])
+    if has_valid_draft(session_matches, session_bench):
+        match_ids = session_matches
+        bench_ids = session_bench
+    else:
+        draft = load_draft_state()
+        if not (
+            isinstance(draft, dict)
+            and draft.get('draft') is True
+            and has_valid_draft(draft.get('matches'), draft.get('bench'))
+        ):
+            return redirect(url_for('match_form'))
+
+        match_ids = draft['matches']
+        bench_ids = draft['bench']
 
     # 対象参加者IDを集める
     confirmed_ids = [pid for group in match_ids for pid in group]
@@ -440,11 +462,9 @@ def confirm_match():
     # 確定状態をファイル保存
     save_match_state_full(True, match_ids, bench_ids, match_count)
 
-    # draft_state を非アクティブ化（draft=False で保存）
-    draft = load_draft_state()
-    if draft:
-        save_draft_state(draft["matches"], draft["bench"], draft=False)  # ← ここでフラグ更新
-    
+    # 確定済み state だけを表示の正とするため、未確定 draft を削除する
+    clear_draft_state()
+
     mode = request.form.get('mode', 'viewer')
     return redirect(url_for('match_result', mode=mode))
 

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -145,3 +145,138 @@ def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert saved_draft["matches"] == [[1, 2, 3, 4]]
     assert saved_draft["bench"] == [5]
+
+
+def configure_confirmation_state(monkeypatch, app_module, initial_state):
+    participants = [SimpleNamespace(id=player_id, games_played=0) for player_id in range(1, 10)]
+
+    class ParticipantId:
+        @staticmethod
+        def in_(player_ids):
+            return set(player_ids)
+
+    class ParticipantQuery:
+        def __init__(self, selected_ids=None):
+            self.selected_ids = selected_ids
+
+        def all(self):
+            if self.selected_ids is None:
+                return participants
+            return [player for player in participants if player.id in self.selected_ids]
+
+        def filter(self, selected_ids):
+            return ParticipantQuery(selected_ids)
+
+    participant_model = SimpleNamespace(id=ParticipantId(), query=ParticipantQuery())
+    state = initial_state.copy()
+
+    def save_state(match_active, matches, bench, match_count):
+        state.update(
+            match_active=match_active,
+            matches=matches,
+            bench=bench,
+            match_count=match_count,
+        )
+
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
+    monkeypatch.setattr(app_module, "save_match_state_full", save_state)
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(commit=lambda: None, remove=lambda: None))
+    return participants, state
+
+
+def test_confirm_match_prefers_valid_session_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    _, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": True, "matches": [[9]], "bench": [], "match_count": 2},
+    )
+    shared_draft = {"draft": True, "matches": [[5, 6, 7, 8]], "bench": [9]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
+    client = app_module.app.test_client()
+    with client.session_transaction() as draft_session:
+        draft_session["draft_matches"] = [[1, 2, 3, 4]]
+        draft_session["draft_bench"] = [5]
+
+    response = client.post("/match/confirm", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match_result?mode=admin")
+    assert state == {
+        "match_active": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "match_count": 3,
+    }
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_confirm_match_uses_active_shared_draft_without_session(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    shared_draft = {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/confirm")
+
+    assert response.status_code == 302
+    assert state == {
+        "match_active": True,
+        "matches": shared_draft["matches"],
+        "bench": shared_draft["bench"],
+        "match_count": 1,
+    }
+    assert [player.games_played for player in participants[:5]] == [1, 1, 1, 1, 0]
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_confirm_match_without_valid_draft_returns_to_match_form(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": True, "matches": [[1, 2, 3, 4]], "bench": [5], "match_count": 4},
+    )
+    inactive_draft = {"draft": False, "matches": [[5, 6, 7, 8]], "bench": [9]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(inactive_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/confirm")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match")
+    assert state == {
+        "match_active": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "match_count": 4,
+    }
+    assert all(player.games_played == 0 for player in participants)
+    assert json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8")) == inactive_draft
+
+
+def test_match_result_uses_confirmed_match_state_after_confirmation(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    _, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    shared_draft = {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
+    client = app_module.app.test_client()
+
+    confirm_response = client.post("/match/confirm")
+    result_response = client.get(confirm_response.headers["Location"])
+
+    assert result_response.status_code == 200
+    assert json.loads(result_response.get_data(as_text=True)) == {
+        "template": "match_result.html",
+        "matches": state["matches"],
+        "bench": state["bench"],
+    }
+    assert not (tmp_path / "draft_state.json").exists()


### PR DESCRIPTION
### Motivation
- 確定処理で session と `draft_state.json` がずれると異なる組み合わせが残る可能性があり、確定対象を一意化して表示の正を `match_state.json` にしたい。
- 既存仕様との互換性を優先し、セッションに有効な draft がある場合はそれを優先する挙動を明確化する必要があった。
- 確定後に未確定の共有 draft が残ると `match_result` の表示と不整合になるため、確定後の draft を適切に扱う必要がある。

### Description
- 追加のヘルパー `has_valid_draft(matches, bench)` を導入して draft の妥当性判定を共通化した。  
- `POST /match/confirm` の処理を変更し、まず session の `draft_matches`/`draft_bench` が有効ならそれを確定対象とし、なければ `load_draft_state()` の `draft: true` な共有 draft にフォールバックし、どちらにも有効 draft がなければ `match_form` へリダイレクトするようにした。  
- 確定後は `save_match_state_full()` で採用した draft を `match_state.json` に保存し、未確定の共有 draft を `clear_draft_state()` で削除することで `match_result` が `match_state.json` を表示の正とするようにした。  
- session 優先・共有 draft フォールバック・draft 不在時の非確定・確定後の draft 削除を検証する回帰テストを `tests/test_match_draft.py` に追加した。 

### Testing
- 実装したケース群を含む `pytest tests/test_match_draft.py` を実行し、該当テスト群が全て成功したことを確認した。  
- リポジトリ全体の `pytest` を実行し、すべてのテストが成功（14 passed）したことを確認した。  
- 追加で `python -m compileall` による構文チェックを行い問題がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf203f6e483338b955e22303ac0a2)