### PR TITLE
Remove confirmed-match session state and use `match_state.json` as source of truth

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,12 +96,14 @@ def generate_card_layout(participants):
 
     return card_map, columns
 
-def render_index_view(mode='viewer', is_match_active=False):
+def render_index_view(mode='viewer'):
     participants = Participant.query.order_by(Participant.card).all()
     card_map, columns = generate_card_layout(participants)
 
     has_draft = 'draft_matches' in session
-    has_confirmed = 'last_confirmed_matches' in session
+    state = load_match_state()
+    has_confirmed = bool(state.get('matches') or state.get('bench'))
+    is_match_active = state.get('match_active', False)
 
     max_rows = max(len(col) for col in columns.values())
 
@@ -440,17 +442,9 @@ def confirm_match():
 
     db.session.commit()
 
-    # 今回の確定結果を保存
-    session['last_confirmed_matches'] = match_ids
-    session['last_confirmed_bench'] = bench_ids
-
     # セッションから一次保存を削除
     session.pop('draft_matches', None)
     session.pop('draft_bench', None)
-
-    # 確定済みの組み合わせを表示用に保存（match_resultで使用）
-    session['last_confirmed_matches'] = match_ids
-    session['last_confirmed_bench'] = bench_ids
 
     # 組み合わせ回数カウントアップ
     state = load_match_state()
@@ -499,10 +493,6 @@ def match_result():
     else:
         match_ids = draft.get('matches', [])
         bench_ids = draft.get('bench', [])
-
-    # 確定済みの組み合わせを優先
-    #match_ids = session.get('last_confirmed_matches')
-    #bench_ids = session.get('last_confirmed_bench', [])  # ← benchもセッションに保存しておく
 
     # 確定済みの組み合わせ
     matches = [[participants[pid] for pid in group] for group in match_ids]
@@ -572,14 +562,12 @@ def reset_db():
 # 管理者向けトップページ
 @app.route('/admin')
 def admin_index():
-    state = load_match_state()
-    return render_index_view(mode='admin', is_match_active=state['match_active'])
+    return render_index_view(mode='admin')
 
 # 参加者向けビュー
 @app.route('/viewer')
 def viewer_index():
-    state = load_match_state()
-    return render_index_view(mode='viewer', is_match_active=state['match_active'])
+    return render_index_view(mode='viewer')
 
 if __name__ == '__main__':
     with app.app_context():

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -209,6 +209,9 @@ def test_confirm_match_prefers_valid_session_draft(monkeypatch, tmp_path):
         "bench": [5],
         "match_count": 3,
     }
+    with client.session_transaction() as confirmed_session:
+        assert "last_confirmed_matches" not in confirmed_session
+        assert "last_confirmed_bench" not in confirmed_session
     assert not (tmp_path / "draft_state.json").exists()
 
 
@@ -280,3 +283,75 @@ def test_match_result_uses_confirmed_match_state_after_confirmation(monkeypatch,
         "bench": state["bench"],
     }
     assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_admin_ignores_stale_confirmed_session_when_shared_state_is_empty(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    app_module.Participant.card = object()
+    app_module.Participant.query.order_by = lambda _: app_module.Participant.query
+    for participant in app_module.Participant.query.all():
+        participant.card = f"card-{participant.id}"
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    monkeypatch.setattr(
+        app_module,
+        "render_template",
+        lambda template, **context: json.dumps(
+            {
+                "template": template,
+                "has_confirmed": context["has_confirmed"],
+            }
+        ),
+    )
+
+    client = app_module.app.test_client()
+    with client.session_transaction() as stale_session:
+        stale_session["last_confirmed_matches"] = [[9]]
+        stale_session["last_confirmed_bench"] = []
+
+    response = client.get("/admin")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        "template": "index.html",
+        "has_confirmed": False,
+    }
+
+
+def test_admin_has_confirmed_when_shared_match_state_has_results(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    app_module.Participant.card = object()
+    app_module.Participant.query.order_by = lambda _: app_module.Participant.query
+    for participant in app_module.Participant.query.all():
+        participant.card = f"card-{participant.id}"
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4]],
+            "bench": [5],
+            "match_count": 1,
+        },
+    )
+    monkeypatch.setattr(
+        app_module,
+        "render_template",
+        lambda template, **context: json.dumps(
+            {
+                "template": template,
+                "has_confirmed": context["has_confirmed"],
+            }
+        ),
+    )
+
+    response = app_module.app.test_client().get("/admin")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        "template": "index.html",
+        "has_confirmed": True,
+    }

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from flask import Flask, session
+
+import utils.reset as reset_module
+
+
+def test_reset_clears_shared_match_state_without_managing_confirmed_session_keys(monkeypatch):
+    app = Flask(__name__)
+    app.secret_key = "test"
+    state = {
+        "match_active": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "match_count": 3,
+    }
+    saved_states = []
+    participants = [SimpleNamespace(games_played=2), SimpleNamespace(games_played=1)]
+
+    monkeypatch.setattr(reset_module, "load_match_state", lambda: state.copy())
+    monkeypatch.setattr(
+        reset_module,
+        "save_match_state_full",
+        lambda *args: saved_states.append(args),
+    )
+    monkeypatch.setattr(
+        reset_module,
+        "Participant",
+        SimpleNamespace(query=SimpleNamespace(all=lambda: participants)),
+    )
+    monkeypatch.setattr(
+        reset_module.db,
+        "session",
+        SimpleNamespace(commit=lambda: None),
+    )
+    monkeypatch.setattr(reset_module, "clear_draft_state", lambda: None)
+
+    with app.test_request_context():
+        session["last_confirmed_matches"] = [[9]]
+        session["last_confirmed_bench"] = [10]
+
+        reset_module.reset_match_state()
+
+        assert saved_states == [(False, [], [], 0)]
+        assert [participant.games_played for participant in participants] == [0, 0]
+        assert session["last_confirmed_matches"] == [[9]]
+        assert session["last_confirmed_bench"] == [10]

--- a/utils/reset.py
+++ b/utils/reset.py
@@ -8,8 +8,6 @@ def reset_match_state():
     session.pop('court_count', None)
     session.pop('draft_matches', None)
     session.pop('draft_bench', None)
-    session.pop('last_confirmed_matches', None)
-    session.pop('last_confirmed_bench', None)
 
     # JSONファイルのリセット
     state = load_match_state()


### PR DESCRIPTION
### Motivation
- The app stored `last_confirmed_matches` / `last_confirmed_bench` in the Flask `session`, duplicating data already kept in `match_state.json` and causing browser-specific differences in whether a UI displayed a confirmed match.
- The goal is to treat `match_state.json` as the single source of truth for confirmed matches and remove the session read/write of those keys with minimal changes.

### Description
- Stop saving `last_confirmed_matches` / `last_confirmed_bench` into the Flask `session` during confirmation in `app.py` and stop reading them for display logic; confirmation continues to persist via `save_match_state_full` to `match_state.json` (no change to persisted behavior).
- Change `render_index_view` to compute `has_confirmed` and `is_match_active` from `load_match_state()` instead of checking session keys, and simplify the `admin` / `viewer` routes to call the new signature.
- Remove `session.pop('last_confirmed_matches', ...)` and `session.pop('last_confirmed_bench', ...)` from `utils/reset.py` so reset no longer touches those session keys.
- Add and update pytest coverage to assert the new behavior: `tests/test_match_draft.py` updated to ensure session does not receive confirmed keys and to validate admin `has_confirmed` logic; `tests/test_reset.py` added to assert reset clears shared state but does not delete the session keys.
- Files changed: `app.py`, `utils/reset.py`, `tests/test_match_draft.py`, and added `tests/test_reset.py`.

### Testing
- Ran `pytest`, all tests passed (`17 passed`).
- Ran `python -m compileall` on `app.py`, `utils/`, and `tests/` with no syntax errors.
- New/updated tests exercised: `tests/test_match_draft.py` (updated assertions for absence of `last_confirmed_*` in session and admin `has_confirmed` behavior) and `tests/test_reset.py` (new test asserting reset clears shared `match_state.json` but does not remove session keys); all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d63e3ef8883338e8ad899d1b632bf)