### PR TITLE
Centralize draft_state.json read/write and active-draft checks in utils/draft_state.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,7 @@ import qrcode
 from logic import generate_matches
 from itertools import zip_longest
 from utils.match_state import load_match_state, save_match_state_full
-from utils.draft_state import save_draft_state, load_draft_state, clear_draft_state
-from utils.match_io import is_draft_active
+from utils.draft_state import clear_draft_state, get_active_draft, save_draft_state
 from utils.score import calculate_pair_score
 from utils.reset import reset_match_state
 from routes.api import api_bp
@@ -301,15 +300,8 @@ def edit_matches():
         match_ids = session['draft_matches']
         bench_ids = session['draft_bench']
     else:
-        draft = load_draft_state()
-        has_active_draft = (
-            isinstance(draft, dict)
-            and draft.get('draft') is True
-            and isinstance(draft.get('matches'), list)
-            and isinstance(draft.get('bench'), list)
-            and (draft['matches'] or draft['bench'])
-        )
-        if not has_active_draft:
+        draft = get_active_draft()
+        if draft is None:
             return redirect(url_for('match_form'))
 
         match_ids = draft['matches']
@@ -422,12 +414,8 @@ def confirm_match():
         match_ids = session_matches
         bench_ids = session_bench
     else:
-        draft = load_draft_state()
-        if not (
-            isinstance(draft, dict)
-            and draft.get('draft') is True
-            and has_valid_draft(draft.get('matches'), draft.get('bench'))
-        ):
+        draft = get_active_draft()
+        if draft is None:
             return redirect(url_for('match_form'))
 
         match_ids = draft['matches']
@@ -484,10 +472,10 @@ def update_court_count():
 def match_result():
     mode = request.args.get('mode', 'viewer')  # デフォルトは viewer
     participants = {p.id: p for p in Participant.query.all()}
-    draft = load_draft_state()
+    draft = get_active_draft()
     state = load_match_state()
 
-    if not is_draft_active():
+    if draft is None:
         match_ids = state.get('matches', [])
         bench_ids = state.get('bench', [])
     else:
@@ -499,7 +487,7 @@ def match_result():
     bench = [participants[pid] for pid in bench_ids] if bench_ids else []
 
     match_count = state.get('match_count', 0)
-    if is_draft_active():
+    if draft is not None:
         match_count += 1  # draft状態では表示上+1
 
     return render_template(
@@ -509,7 +497,7 @@ def match_result():
         card_to_filename=card_to_filename,
         match_count=match_count,
         mode=mode,
-        is_draft=is_draft_active()
+        is_draft=draft is not None
     )
 
 @app.route('/reset_match', methods=['POST'])

--- a/tests/test_draft_state.py
+++ b/tests/test_draft_state.py
@@ -1,0 +1,84 @@
+import json
+
+from utils.draft_state import (
+    clear_draft_state,
+    get_active_draft,
+    is_active_draft,
+    load_draft_state,
+    save_draft_state,
+)
+
+
+def test_valid_draft_state_is_active():
+    state = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+
+    assert is_active_draft(state) is True
+
+
+def test_draft_false_is_not_active():
+    state = {
+        "draft": False,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+
+    assert is_active_draft(state) is False
+
+
+def test_empty_draft_is_not_active():
+    state = {
+        "draft": True,
+        "matches": [],
+        "bench": [],
+    }
+
+    assert is_active_draft(state) is False
+
+
+def test_draft_with_only_matches_is_active():
+    state = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [],
+    }
+
+    assert is_active_draft(state) is True
+
+
+def test_draft_with_only_bench_is_active():
+    state = {
+        "draft": True,
+        "matches": [],
+        "bench": [1],
+    }
+
+    assert is_active_draft(state) is True
+
+
+def test_clear_draft_state_removes_active_draft(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    save_draft_state([[1, 2, 3, 4]], [5])
+
+    assert get_active_draft() == load_draft_state()
+
+    clear_draft_state()
+
+    assert get_active_draft() is None
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_save_draft_state_keeps_existing_schema(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    save_draft_state([[1, 2, 3, 4]], [5])
+
+    state = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert state["draft"] is True
+    assert state["matches"] == [[1, 2, 3, 4]]
+    assert state["bench"] == [5]
+    assert "timestamp" in state
+    assert "court_count" not in state

--- a/tests/test_draft_state.py
+++ b/tests/test_draft_state.py
@@ -29,13 +29,20 @@ def test_draft_false_is_not_active():
     assert is_active_draft(state) is False
 
 
-def test_empty_draft_is_not_active():
+def test_empty_draft_true_is_active():
     state = {
         "draft": True,
         "matches": [],
         "bench": [],
     }
+    assert is_active_draft(state) is True
 
+def test_empty_draft_false_is_not_active():
+    state = {
+        "draft": False,
+        "matches": [],
+        "bench": [],
+    }
     assert is_active_draft(state) is False
 
 

--- a/utils/draft_state.py
+++ b/utils/draft_state.py
@@ -12,9 +12,9 @@ def load_draft_state():
         return json.load(f)
 
 
-def save_draft_state(matches, bench, court_count=None):
+def save_draft_state(matches, bench, draft=True,court_count=None):
     data = {
-        "draft": True,
+        "draft": draft,
         "timestamp": datetime.now().astimezone().isoformat(),
         "matches": matches,
         "bench": bench,

--- a/utils/draft_state.py
+++ b/utils/draft_state.py
@@ -1,25 +1,46 @@
-from datetime import datetime
-import os
 import json
+import os
+from datetime import datetime
 
 DRAFT_FILE = 'draft_state.json'
 
-def save_draft_state(matches, bench, draft=True):
-    data = {
-        "draft": draft,
-        "timestamp": datetime.now().astimezone().isoformat(),
-        "matches": matches,
-        "bench": bench
-    }
-    with open(DRAFT_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f)
 
 def load_draft_state():
     if not os.path.exists(DRAFT_FILE):
         return None
-    with open(DRAFT_FILE, 'r') as f:
+    with open(DRAFT_FILE, encoding="utf-8") as f:
         return json.load(f)
+
+
+def save_draft_state(matches, bench, court_count=None):
+    data = {
+        "draft": True,
+        "timestamp": datetime.now().astimezone().isoformat(),
+        "matches": matches,
+        "bench": bench,
+    }
+    if court_count is not None:
+        data["court_count"] = court_count
+
+    with open(DRAFT_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
 
 def clear_draft_state():
     if os.path.exists(DRAFT_FILE):
         os.remove(DRAFT_FILE)
+
+
+def is_active_draft(state):
+    return (
+        isinstance(state, dict)
+        and state.get("draft") is True
+        and isinstance(state.get("matches"), list)
+        and isinstance(state.get("bench"), list)
+        and bool(state["matches"] or state["bench"])
+    )
+
+
+def get_active_draft():
+    state = load_draft_state()
+    return state if is_active_draft(state) else None

--- a/utils/draft_state.py
+++ b/utils/draft_state.py
@@ -37,7 +37,6 @@ def is_active_draft(state):
         and state.get("draft") is True
         and isinstance(state.get("matches"), list)
         and isinstance(state.get("bench"), list)
-        and bool(state["matches"] or state["bench"])
     )
 
 

--- a/utils/match_io.py
+++ b/utils/match_io.py
@@ -1,9 +1,5 @@
-import os
-import json
+from utils.draft_state import get_active_draft
+
 
 def is_draft_active():
-    if not os.path.exists("draft_state.json"):
-        return False
-    with open("draft_state.json", encoding="utf-8") as f:
-        data = json.load(f)
-        return data.get("draft", False)
+    return get_active_draft() is not None


### PR DESCRIPTION
### Motivation
- Consolidate scattered draft read/write and validity checks into a single utility to make it easier to migrate draft canonical storage from session to `draft_state.json` in follow-up work.

### Description
- Add `load_draft_state()`, `save_draft_state(matches, bench, court_count=None)`, `clear_draft_state()`, `is_active_draft(state)`, and `get_active_draft()` in `utils/draft_state.py` to centralize draft persistence and validation.
- Replace duplicated draft-validity logic in `/match/edit`, `/match/confirm`, and `/match_result` to use `get_active_draft()` while keeping session-first behavior unchanged.
- Keep `utils/match_io.is_draft_active()` as a compatibility wrapper that now delegates to `get_active_draft()`.
- Add `tests/test_draft_state.py` which validates the active-draft rules, `clear_draft_state()` behavior, and schema compatibility of saved drafts.

### Testing
- Ran `pytest` and all tests passed (`24 passed`).
- Verified code compiles with `python -m compileall` and no diff/check issues were reported by `git diff --check`.
- Executed the new draft unit tests which confirm correct active/inactive detection, clearing behavior, and that the existing draft schema is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea4ca25588333845face42f04ae63)