### PR TITLE
Persist draft edits to shared state for swap and court count

### DIFF
--- a/app.py
+++ b/app.py
@@ -285,7 +285,7 @@ def match_form():
     session['draft_bench'] = bench_ids
 
     # draft_state.jsonもIDベースで保存
-    save_draft_state(match_ids, bench_ids)
+    save_draft_state(match_ids, bench_ids, court_count=court_count)
 
     state['match_active'] = True
     save_match_state_full(state.get('match_active', True), state.get('matches', []), state.get('bench', []), state.get('match_count', 0))
@@ -365,15 +365,20 @@ def edit_matches():
 def swap_players():
     raw = request.form.get('swap_ids', '')
     selected_ids = raw.split(',') if raw else []
+    mode = request.form.get('mode', 'viewer')
 
     if len(selected_ids) != 2:
-        return redirect(url_for('edit_matches'))  # 2人以外選ばれてたら無視
+        return redirect(url_for('edit_matches', mode=mode))  # 2人以外選ばれてたら無視
 
     id1, id2 = map(int, selected_ids)
 
-    # 現在の状態を取得
-    match_ids = session.get('draft_matches', [])
-    bench_ids = session.get('draft_bench', [])
+    # 共有中の未確定 draft を正として現在の状態を取得
+    draft = get_active_draft()
+    if draft is None:
+        return redirect(url_for('match_form', mode=mode))
+
+    match_ids = draft['matches']
+    bench_ids = draft['bench']
 
     # 両方をまとめて探索・入れ替え
     all_groups = match_ids + [bench_ids]  # 最後の1枠は bench 扱い
@@ -393,7 +398,11 @@ def swap_players():
     session['draft_matches'] = match_ids
     session['draft_bench'] = new_bench_ids
 
-    mode = request.form.get('mode', 'viewer')
+    save_draft_state(
+        match_ids,
+        new_bench_ids,
+        court_count=draft.get('court_count'),
+    )
 
     return redirect(url_for('edit_matches', mode=mode))
 
@@ -461,8 +470,11 @@ def update_court_count():
     # 新しい組み合わせ生成
     matches, bench = generate_matches(participants, new_count)
     print(matches, bench)
-    session['draft_matches'] = [[p.id for p in group] for group in matches]
-    session['draft_bench'] = [p.id for p in bench]
+    match_ids = [[p.id for p in group] for group in matches]
+    bench_ids = [p.id for p in bench]
+    session['draft_matches'] = match_ids
+    session['draft_bench'] = bench_ids
+    save_draft_state(match_ids, bench_ids, court_count=new_count)
 
     mode = request.form.get('mode', 'viewer')
 

--- a/app.py
+++ b/app.py
@@ -295,12 +295,13 @@ def match_form():
 
 @app.route('/match/edit')
 def edit_matches():
+    draft = get_active_draft()
+
     # セッションに仮組み合わせがなければ共有 draft から復元する
     if 'draft_matches' in session and 'draft_bench' in session:
         match_ids = session['draft_matches']
         bench_ids = session['draft_bench']
     else:
-        draft = get_active_draft()
         if draft is None:
             return redirect(url_for('match_form'))
 
@@ -327,7 +328,8 @@ def edit_matches():
     matches = [[mark_bench_player(participants[pid]) for pid in group] for group in match_ids]
     bench = [mark_bench_player(participants[pid]) for pid in bench_ids]
 
-    court_count = session.get('court_count', 1)
+    draft_court_count = draft.get('court_count') if draft is not None else None
+    court_count = draft_court_count or session.get('court_count', 1)
     match_count = get_match_count()
     mode = request.args.get('mode', 'viewer')
 
@@ -348,7 +350,7 @@ def edit_matches():
     # IDリストに変換して保存
     id_matches = [[p.id for p in group] for group in matches]
     id_bench = [p.id for p in bench]
-    save_draft_state(id_matches, id_bench)
+    save_draft_state(id_matches, id_bench, court_count=draft_court_count)
 
     return render_template(
         'match_edit.html',

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -28,7 +28,7 @@ def test_creating_draft_preserves_confirmed_matches(monkeypatch, tmp_path):
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(app_module, "generate_matches", lambda players, courts: ([players[:4]], players[4:]))
     monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
-    monkeypatch.setattr(app_module, "save_draft_state", lambda matches, bench: None)
+    monkeypatch.setattr(app_module, "save_draft_state", lambda matches, bench, **kwargs: None)
     monkeypatch.setattr(app_module, "save_match_state_full", lambda *args: saved_state.append(args))
 
     response = app_module.app.test_client().post("/match", data={"court_count": "1"})
@@ -145,6 +145,81 @@ def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert saved_draft["matches"] == [[1, 2, 3, 4]]
     assert saved_draft["bench"] == [5]
+
+
+def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    draft = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "court_count": 1,
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post(
+        "/match/swap",
+        data={"swap_ids": "1,5", "mode": "admin"},
+    )
+
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    assert saved_draft["matches"] == [[5, 2, 3, 4]]
+    assert saved_draft["bench"] == [1]
+    assert saved_draft["court_count"] == 1
+
+
+def test_swap_players_without_active_draft_does_not_overwrite_state(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    inactive_draft = {
+        "draft": False,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+    }
+    draft_path = tmp_path / "draft_state.json"
+    draft_path.write_text(json.dumps(inactive_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post(
+        "/match/swap",
+        data={"swap_ids": "1,5", "mode": "admin"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match?mode=admin")
+    assert json.loads(draft_path.read_text(encoding="utf-8")) == inactive_draft
+
+
+def test_update_court_count_saves_shared_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 7)]
+
+    class ParticipantQuery:
+        def filter_by(self, **kwargs):
+            assert kwargs == {"active": True}
+            return self
+
+        def all(self):
+            return participants
+
+    app_module.Participant.query = ParticipantQuery()
+    monkeypatch.setattr(
+        app_module,
+        "generate_matches",
+        lambda players, courts: ([players[:4]], players[4:]),
+    )
+
+    response = app_module.app.test_client().post(
+        "/update_court_count",
+        data={"court_count": "2", "mode": "admin"},
+    )
+
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    assert saved_draft["matches"] == [[1, 2, 3, 4]]
+    assert saved_draft["bench"] == [5, 6]
+    assert saved_draft["court_count"] == 2
 
 
 def configure_confirmation_state(monkeypatch, app_module, initial_state):

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -64,6 +64,7 @@ def load_test_app(monkeypatch, tmp_path):
                 "template": template,
                 "matches": [[player.id for player in group] for group in context.get("matches", [])],
                 "bench": [player.id for player in context.get("bench", [])],
+                **({"court_count": context.get("court_count")} if template == "match_edit.html" else {}),
             }
         ),
     )
@@ -77,6 +78,7 @@ def test_match_edit_without_session_does_not_clear_shared_draft(monkeypatch, tmp
         "timestamp": "2026-06-12T00:00:00+00:00",
         "matches": [[1, 2, 3, 4]],
         "bench": [5],
+        "court_count": 2,
     }
     (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
 
@@ -86,6 +88,7 @@ def test_match_edit_without_session_does_not_clear_shared_draft(monkeypatch, tmp
     assert response.status_code == 200
     assert saved_draft["matches"] == draft["matches"]
     assert saved_draft["bench"] == draft["bench"]
+    assert saved_draft["court_count"] == draft["court_count"]
 
 
 def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_path):
@@ -94,6 +97,7 @@ def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_pat
         "draft": True,
         "matches": [[1, 2, 3, 4]],
         "bench": [5],
+        "court_count": 3,
     }
     (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
     client = app_module.app.test_client()
@@ -105,6 +109,7 @@ def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_pat
         "template": "match_edit.html",
         "matches": draft["matches"],
         "bench": draft["bench"],
+        "court_count": draft["court_count"],
     }
     with client.session_transaction() as draft_session:
         assert draft_session["draft_matches"] == draft["matches"]
@@ -127,6 +132,7 @@ def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
         "draft": True,
         "matches": [[5, 4, 3, 2]],
         "bench": [1],
+        "court_count": 4,
     }
     (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
     client = app_module.app.test_client()
@@ -141,10 +147,12 @@ def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
         "template": "match_edit.html",
         "matches": [[1, 2, 3, 4]],
         "bench": [5],
+        "court_count": shared_draft["court_count"],
     }
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert saved_draft["matches"] == [[1, 2, 3, 4]]
     assert saved_draft["bench"] == [5]
+    assert saved_draft["court_count"] == shared_draft["court_count"]
 
 
 def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
@@ -167,6 +175,11 @@ def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
     assert response.headers["Location"].endswith("/match/edit?mode=admin")
     assert saved_draft["matches"] == [[5, 2, 3, 4]]
     assert saved_draft["bench"] == [1]
+    assert saved_draft["court_count"] == 1
+
+    edit_response = app_module.app.test_client().get(response.headers["Location"])
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert edit_response.status_code == 200
     assert saved_draft["court_count"] == 1
 
 
@@ -219,6 +232,11 @@ def test_update_court_count_saves_shared_draft(monkeypatch, tmp_path):
     assert response.headers["Location"].endswith("/match/edit?mode=admin")
     assert saved_draft["matches"] == [[1, 2, 3, 4]]
     assert saved_draft["bench"] == [5, 6]
+    assert saved_draft["court_count"] == 2
+
+    edit_response = app_module.app.test_client().get(response.headers["Location"])
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert edit_response.status_code == 200
     assert saved_draft["court_count"] == 2
 
 


### PR DESCRIPTION
### Motivation
- Prevent divergence between a client session’s draft and the shared draft by applying edit operations directly to `draft_state.json` instead of only mutating the Flask session.  
- Target the two routes that previously updated only session state: `/match/swap` and `/update_court_count`.  
- Preserve existing UI and flow while making shared draft updates visible to other clients immediately.

### Description
- When generating a new draft (`/match`), save `court_count` into the shared draft by calling `save_draft_state(match_ids, bench_ids, court_count=court_count)` in `app.py`.  
- Replace session-only behavior in `swap_players()` so it reads the current shared draft via `get_active_draft()`, aborts safely back to `match_form` when no active draft exists, applies the swap on the draft `matches`/`bench`, and writes the result back with `save_draft_state(..., court_count=draft.get('court_count'))`; session entries are still updated for the current client.  
- Update `update_court_count()` to compute new `matches`/`bench`, update the session, and persist `match_ids`/`bench_ids` plus `court_count` into `draft_state.json` via `save_draft_state(match_ids, bench_ids, court_count=new_count)`.  
- Add regression tests in `tests/test_match_draft.py` verifying immediate shared-draft updates for swap, safety when no active draft exists, and saving `court_count` on court-count changes, and adapt a test helper mock to accept `**kwargs` for `save_draft_state` calls.

### Testing
- Ran `pytest tests/test_match_draft.py tests/test_draft_state.py` during development and iterated on a failing mock signature; fixed the mock and reran tests.  
- Ran full test suite with `pytest` and all tests passed: `28 passed`.  
- Verified repository diffs and the changed files are `app.py` and `tests/test_match_draft.py` and that updates are limited to the described behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3010ef633083338ca03bb9d82aaa36)