### PR TITLE
Prefer draft_state.json for /match/edit and /match/confirm

### DIFF
--- a/app.py
+++ b/app.py
@@ -297,18 +297,15 @@ def match_form():
 def edit_matches():
     draft = get_active_draft()
 
-    # セッションに仮組み合わせがなければ共有 draft から復元する
-    if 'draft_matches' in session and 'draft_bench' in session:
-        match_ids = session['draft_matches']
-        bench_ids = session['draft_bench']
-    else:
-        if draft is None:
-            return redirect(url_for('match_form'))
+    # 共有中の未確定 draft を表示元の正とする。
+    # 古いブラウザセッションに残った draft は共有 draft で上書きして互換維持する。
+    if draft is None:
+        return redirect(url_for('match_form'))
 
-        match_ids = draft['matches']
-        bench_ids = draft['bench']
-        session['draft_matches'] = match_ids
-        session['draft_bench'] = bench_ids
+    match_ids = draft['matches']
+    bench_ids = draft['bench']
+    session['draft_matches'] = match_ids
+    session['draft_bench'] = bench_ids
 
     participants = {p.id: p for p in Participant.query.all()}
     
@@ -346,11 +343,6 @@ def edit_matches():
         pairs = [group[i:i+2] for i in range(0, len(group), 2)]
         scored_pairs = [calculate_pair_score(pair, level_map, gender_weight) for pair in pairs]
         match_data.append(scored_pairs)
-
-    # IDリストに変換して保存
-    id_matches = [[p.id for p in group] for group in matches]
-    id_bench = [p.id for p in bench]
-    save_draft_state(id_matches, id_bench, court_count=draft_court_count)
 
     return render_template(
         'match_edit.html',
@@ -418,19 +410,13 @@ def has_valid_draft(matches, bench):
 
 @app.route('/match/confirm', methods=['POST'])
 def confirm_match():
-    session_matches = session.get('draft_matches')
-    session_bench = session.get('draft_bench')
+    # 共有中の未確定 draft を確定対象の正とし、古い session draft は採用しない。
+    draft = get_active_draft()
+    if draft is None:
+        return redirect(url_for('match_form'))
 
-    if has_valid_draft(session_matches, session_bench):
-        match_ids = session_matches
-        bench_ids = session_bench
-    else:
-        draft = get_active_draft()
-        if draft is None:
-            return redirect(url_for('match_form'))
-
-        match_ids = draft['matches']
-        bench_ids = draft['bench']
+    match_ids = draft['matches']
+    bench_ids = draft['bench']
 
     # 対象参加者IDを集める
     confirmed_ids = [pid for group in match_ids for pid in group]

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -126,7 +126,7 @@ def test_match_edit_without_available_draft_redirects_to_match_form(monkeypatch,
     assert not (tmp_path / "draft_state.json").exists()
 
 
-def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
+def test_match_edit_prefers_active_shared_draft_over_session_draft(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     shared_draft = {
         "draft": True,
@@ -145,14 +145,29 @@ def test_match_edit_keeps_using_existing_session_draft(monkeypatch, tmp_path):
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {
         "template": "match_edit.html",
-        "matches": [[1, 2, 3, 4]],
-        "bench": [5],
+        "matches": shared_draft["matches"],
+        "bench": shared_draft["bench"],
         "court_count": shared_draft["court_count"],
     }
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
-    assert saved_draft["matches"] == [[1, 2, 3, 4]]
-    assert saved_draft["bench"] == [5]
-    assert saved_draft["court_count"] == shared_draft["court_count"]
+    assert saved_draft == shared_draft
+    with client.session_transaction() as draft_session:
+        assert draft_session["draft_matches"] == shared_draft["matches"]
+        assert draft_session["draft_bench"] == shared_draft["bench"]
+
+
+def test_match_edit_without_active_shared_draft_ignores_stale_session_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    client = app_module.app.test_client()
+    with client.session_transaction() as draft_session:
+        draft_session["draft_matches"] = [[1, 2, 3, 4]]
+        draft_session["draft_bench"] = [5]
+
+    response = client.get("/match/edit")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match")
+    assert not (tmp_path / "draft_state.json").exists()
 
 
 def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
@@ -278,7 +293,7 @@ def configure_confirmation_state(monkeypatch, app_module, initial_state):
     return participants, state
 
 
-def test_confirm_match_prefers_valid_session_draft(monkeypatch, tmp_path):
+def test_confirm_match_prefers_active_shared_draft_over_session_draft(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     _, state = configure_confirmation_state(
         monkeypatch,
@@ -298,8 +313,8 @@ def test_confirm_match_prefers_valid_session_draft(monkeypatch, tmp_path):
     assert response.headers["Location"].endswith("/match_result?mode=admin")
     assert state == {
         "match_active": True,
-        "matches": [[1, 2, 3, 4]],
-        "bench": [5],
+        "matches": shared_draft["matches"],
+        "bench": shared_draft["bench"],
         "match_count": 3,
     }
     with client.session_transaction() as confirmed_session:
@@ -340,8 +355,12 @@ def test_confirm_match_without_valid_draft_returns_to_match_form(monkeypatch, tm
     )
     inactive_draft = {"draft": False, "matches": [[5, 6, 7, 8]], "bench": [9]}
     (tmp_path / "draft_state.json").write_text(json.dumps(inactive_draft), encoding="utf-8")
+    client = app_module.app.test_client()
+    with client.session_transaction() as draft_session:
+        draft_session["draft_matches"] = [[5, 6, 7, 8]]
+        draft_session["draft_bench"] = [9]
 
-    response = app_module.app.test_client().post("/match/confirm")
+    response = client.post("/match/confirm")
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/match")


### PR DESCRIPTION
### Motivation
- The app could display or confirm stale per-client drafts stored in Flask `session` instead of the shared `draft_state.json`, causing inconsistent behavior across browsers and sessions. 
- Recent work centralized draft read/write/validation in `utils/draft_state.py` and updated mutating endpoints, so the edit/confirm flows should also treat the shared active draft as the source of truth.

### Description
- Updated `/match/edit` in `app.py` to obtain the draft with `get_active_draft()` and, when an active shared draft exists, use its `matches`/`bench` (and `court_count`) as the display source while mirroring them into `session` for compatibility. 
- Removed the render-time `save_draft_state(...)` call from the edit view so opening the edit screen no longer rewrites `draft_state.json` or clears `court_count` metadata. 
- Updated `/match/confirm` in `app.py` to always confirm the active shared draft from `draft_state.json`, ignore stale `session` drafts, redirect safely to the match form when no active draft exists, and continue to save confirmed state via existing `save_match_state_full()` and clear the draft with `clear_draft_state()`. 
- Tests in `tests/test_match_draft.py` were adjusted/added to assert that `draft_state.json` is preferred over `session` drafts, that no active draft causes safe redirects, and that `court_count` is preserved when rendering the edit screen.

### Testing
- Ran `pytest tests/test_match_draft.py -q` and the test module passed; the updated test cases exercise preference of shared draft, ignoring stale session drafts, and court count preservation. 
- Ran full test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31573be18083339452bc791a61d10f)