### PR TITLE
Remove session-backed draft state and use draft_state.json as source of truth

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import json
 import io
 import logging
 from io import TextIOWrapper
-from flask import Flask, render_template, request, redirect, url_for, session, abort
+from flask import Flask, render_template, request, redirect, url_for, abort
 from models import db, Participant 
 # from flask_sqlalchemy import SQLAlchemy
 from flask import flash
@@ -53,9 +53,19 @@ GENDER_WEIGHT = config.get("gender_weight", {})
 def get_match_count():
     state = load_match_state()
     count = state['match_count']
-    if 'draft_matches' in session:
+    if get_active_draft() is not None:
         return count + 1  # 表示上だけ+1
     return count
+
+
+def get_draft_court_count(draft):
+    court_count = draft.get('court_count')
+    if isinstance(court_count, int) and court_count > 0:
+        return court_count
+    matches = draft.get('matches', [])
+    if isinstance(matches, list) and matches:
+        return len(matches)
+    return 1
 
 def card_to_filename(card):
     if card.startswith('JOKER'):
@@ -99,7 +109,7 @@ def render_index_view(mode='viewer'):
     participants = Participant.query.order_by(Participant.card).all()
     card_map, columns = generate_card_layout(participants)
 
-    has_draft = 'draft_matches' in session
+    has_draft = get_active_draft() is not None
     state = load_match_state()
     has_confirmed = bool(state.get('matches') or state.get('bench'))
     is_match_active = state.get('match_active', False)
@@ -261,13 +271,11 @@ def match_form():
 
     mode = request.form.get('mode', 'admin')
 
+    court_count = None
     if request.method == 'POST':
-        # 値が送られてきたときだけcourt_countを更新
         form_value = request.form.get('court_count')
         if form_value:
-            session['court_count'] = int(form_value)
-        
-    court_count = session.get('court_count')
+            court_count = int(form_value)
 
     if court_count is None:
         # 最初のアクセス or リセット後はフォーム表示
@@ -280,11 +288,7 @@ def match_form():
     match_ids = [[p.id for p in group] for group in matches]
     bench_ids = [p.id for p in bench]
 
-    # セッションにもIDを保存
-    session['draft_matches'] = match_ids
-    session['draft_bench'] = bench_ids
-
-    # draft_state.jsonもIDベースで保存
+    # draft_state.jsonをIDベースで保存
     save_draft_state(match_ids, bench_ids, court_count=court_count)
 
     state['match_active'] = True
@@ -298,14 +302,11 @@ def edit_matches():
     draft = get_active_draft()
 
     # 共有中の未確定 draft を表示元の正とする。
-    # 古いブラウザセッションに残った draft は共有 draft で上書きして互換維持する。
     if draft is None:
         return redirect(url_for('match_form'))
 
     match_ids = draft['matches']
     bench_ids = draft['bench']
-    session['draft_matches'] = match_ids
-    session['draft_bench'] = bench_ids
 
     participants = {p.id: p for p in Participant.query.all()}
     
@@ -325,8 +326,7 @@ def edit_matches():
     matches = [[mark_bench_player(participants[pid]) for pid in group] for group in match_ids]
     bench = [mark_bench_player(participants[pid]) for pid in bench_ids]
 
-    draft_court_count = draft.get('court_count') if draft is not None else None
-    court_count = draft_court_count or session.get('court_count', 1)
+    court_count = get_draft_court_count(draft)
     match_count = get_match_count()
     mode = request.args.get('mode', 'viewer')
 
@@ -389,9 +389,6 @@ def swap_players():
     all_selected_ids = used_ids.union(set(bench_ids))
     new_bench_ids = [pid for pid in all_selected_ids if pid not in used_ids]
 
-    session['draft_matches'] = match_ids
-    session['draft_bench'] = new_bench_ids
-
     save_draft_state(
         match_ids,
         new_bench_ids,
@@ -427,10 +424,6 @@ def confirm_match():
 
     db.session.commit()
 
-    # セッションから一次保存を削除
-    session.pop('draft_matches', None)
-    session.pop('draft_bench', None)
-
     # 組み合わせ回数カウントアップ
     state = load_match_state()
     match_count = state.get('match_count', 0) + 1
@@ -450,18 +443,14 @@ def confirm_match():
 @app.route('/update_court_count', methods=['POST'])
 def update_court_count():
     new_count = int(request.form['court_count'])
-    session['court_count'] = new_count
 
     # 参加者データ取得
     participants = Participant.query.filter_by(active=True).all()
 
     # 新しい組み合わせ生成
     matches, bench = generate_matches(participants, new_count)
-    print(matches, bench)
     match_ids = [[p.id for p in group] for group in matches]
     bench_ids = [p.id for p in bench]
-    session['draft_matches'] = match_ids
-    session['draft_bench'] = bench_ids
     save_draft_state(match_ids, bench_ids, court_count=new_count)
 
     mode = request.form.get('mode', 'viewer')

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -31,10 +31,15 @@ def test_creating_draft_preserves_confirmed_matches(monkeypatch, tmp_path):
     monkeypatch.setattr(app_module, "save_draft_state", lambda matches, bench, **kwargs: None)
     monkeypatch.setattr(app_module, "save_match_state_full", lambda *args: saved_state.append(args))
 
-    response = app_module.app.test_client().post("/match", data={"court_count": "1"})
+    client = app_module.app.test_client()
+    response = client.post("/match", data={"court_count": "1"})
 
     assert response.status_code == 302
     assert saved_state == [(True, confirmed_matches, [15], 3)]
+    with client.session_transaction() as draft_session:
+        assert "draft_matches" not in draft_session
+        assert "draft_bench" not in draft_session
+        assert "court_count" not in draft_session
 
 
 def load_test_app(monkeypatch, tmp_path):
@@ -91,7 +96,7 @@ def test_match_edit_without_session_does_not_clear_shared_draft(monkeypatch, tmp
     assert saved_draft["court_count"] == draft["court_count"]
 
 
-def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_path):
+def test_match_edit_uses_active_shared_draft_without_saving_session(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     draft = {
         "draft": True,
@@ -112,8 +117,9 @@ def test_match_edit_restores_active_shared_draft_to_session(monkeypatch, tmp_pat
         "court_count": draft["court_count"],
     }
     with client.session_transaction() as draft_session:
-        assert draft_session["draft_matches"] == draft["matches"]
-        assert draft_session["draft_bench"] == draft["bench"]
+        assert "draft_matches" not in draft_session
+        assert "draft_bench" not in draft_session
+        assert "court_count" not in draft_session
 
 
 def test_match_edit_without_available_draft_redirects_to_match_form(monkeypatch, tmp_path):
@@ -152,8 +158,34 @@ def test_match_edit_prefers_active_shared_draft_over_session_draft(monkeypatch, 
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert saved_draft == shared_draft
     with client.session_transaction() as draft_session:
-        assert draft_session["draft_matches"] == shared_draft["matches"]
-        assert draft_session["draft_bench"] == shared_draft["bench"]
+        assert draft_session["draft_matches"] == [[1, 2, 3, 4]]
+        assert draft_session["draft_bench"] == [5]
+        assert "court_count" not in draft_session
+
+
+def test_match_edit_uses_match_count_when_shared_draft_has_old_schema(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    old_schema_draft = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4], [5]],
+        "bench": [],
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(old_schema_draft), encoding="utf-8")
+    client = app_module.app.test_client()
+
+    response = client.get("/match/edit")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        "template": "match_edit.html",
+        "matches": old_schema_draft["matches"],
+        "bench": old_schema_draft["bench"],
+        "court_count": 2,
+    }
+    with client.session_transaction() as draft_session:
+        assert "draft_matches" not in draft_session
+        assert "draft_bench" not in draft_session
+        assert "court_count" not in draft_session
 
 
 def test_match_edit_without_active_shared_draft_ignores_stale_session_draft(monkeypatch, tmp_path):
@@ -180,7 +212,8 @@ def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
     }
     (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
 
-    response = app_module.app.test_client().post(
+    client = app_module.app.test_client()
+    response = client.post(
         "/match/swap",
         data={"swap_ids": "1,5", "mode": "admin"},
     )
@@ -192,10 +225,14 @@ def test_swap_players_updates_shared_draft_immediately(monkeypatch, tmp_path):
     assert saved_draft["bench"] == [1]
     assert saved_draft["court_count"] == 1
 
-    edit_response = app_module.app.test_client().get(response.headers["Location"])
+    edit_response = client.get(response.headers["Location"])
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert edit_response.status_code == 200
     assert saved_draft["court_count"] == 1
+    with client.session_transaction() as draft_session:
+        assert "draft_matches" not in draft_session
+        assert "draft_bench" not in draft_session
+        assert "court_count" not in draft_session
 
 
 def test_swap_players_without_active_draft_does_not_overwrite_state(monkeypatch, tmp_path):
@@ -237,7 +274,8 @@ def test_update_court_count_saves_shared_draft(monkeypatch, tmp_path):
         lambda players, courts: ([players[:4]], players[4:]),
     )
 
-    response = app_module.app.test_client().post(
+    client = app_module.app.test_client()
+    response = client.post(
         "/update_court_count",
         data={"court_count": "2", "mode": "admin"},
     )
@@ -249,10 +287,14 @@ def test_update_court_count_saves_shared_draft(monkeypatch, tmp_path):
     assert saved_draft["bench"] == [5, 6]
     assert saved_draft["court_count"] == 2
 
-    edit_response = app_module.app.test_client().get(response.headers["Location"])
+    edit_response = client.get(response.headers["Location"])
     saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
     assert edit_response.status_code == 200
     assert saved_draft["court_count"] == 2
+    with client.session_transaction() as draft_session:
+        assert "draft_matches" not in draft_session
+        assert "draft_bench" not in draft_session
+        assert "court_count" not in draft_session
 
 
 def configure_confirmation_state(monkeypatch, app_module, initial_state):

--- a/utils/reset.py
+++ b/utils/reset.py
@@ -1,14 +1,8 @@
-from flask import session
 from models import Participant, db
 from utils.match_state import load_match_state, save_match_state_full
 from utils.draft_state import clear_draft_state
 
 def reset_match_state():
-    # セッション情報のリセット
-    session.pop('court_count', None)
-    session.pop('draft_matches', None)
-    session.pop('draft_bench', None)
-
     # JSONファイルのリセット
     state = load_match_state()
     state['match_active'] = False


### PR DESCRIPTION
### Motivation
- Consolidate draft handling so the app treats `draft_state.json` as the single source of truth and stop persisting transient draft data in Flask `session` to avoid stale client-side state.
- Keep backward compatibility for older draft schema that lacks `court_count` by deriving a safe default instead of depending on `session`.
- Reduce reset complexity by removing obsolete session cleanup for draft-related keys while preserving existing `match_state.json` and participant `games_played` reset behavior.

### Description
- Replaced session-based draft indicators with `get_active_draft()` checks and added `get_draft_court_count(draft)` in `app.py` to prefer `draft_state.json` and safely derive `court_count` for old schemas.
- Stopped writing `session['draft_matches']`, `session['draft_bench']`, and `session['court_count']` in the draft creation (`/match`), swap (`/match/swap`), confirm (`/match/confirm`), and court-count update (`/update_court_count`) flows, and stopped reading them as authoritative in edit/confirm flows.
- Removed session pop cleanup for draft keys from `confirm_match` and removed session key removal from `utils/reset.py` so reset focuses on shared JSON state and DB updates; `flash()` usage remains unchanged.
- Updated `tests/test_match_draft.py` to reflect the new behavior (asserting draft data is not newly stored in session and adding a test for old-schema drafts deriving `court_count`), and left reset behavior tests intact in `tests/test_reset.py`.

### Testing
- Ran the full test suite with `pytest`, and all tests passed (`30 passed`).
- Ran focused runs of `tests/test_match_draft.py` and `tests/test_reset.py` after edits and they passed (`17` and `1`/`16` earlier, now included in full suite).
- Verified no `git diff --check` issues were reported during the changes (automated check succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32af66f4088333b0feb5b2081b5039)