### PR TITLE
Centralize flash message rendering

### DIFF
--- a/templates/_flash_messages.html
+++ b/templates/_flash_messages.html
@@ -1,0 +1,36 @@
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <style>
+            .flash-messages {
+                list-style: none;
+                padding: 0;
+                margin: 0 0 20px;
+            }
+
+            .flash-messages li {
+                padding: 10px;
+                border-radius: 5px;
+                margin-bottom: 10px;
+                text-align: center;
+            }
+
+            .flash-messages .error {
+                color: #e74c3c;
+                background-color: #fbeaea;
+                border: 1px solid #e74c3c;
+            }
+
+            .flash-messages .message,
+            .flash-messages .info {
+                color: #155724;
+                background-color: #d4edda;
+                border: 1px solid #c3e6cb;
+            }
+        </style>
+        <ul class="flash-messages" role="status" aria-live="polite">
+            {% for category, message in messages %}
+                <li class="{{ category }}">{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endwith %}

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -5,6 +5,7 @@
     <title>管理者設定</title>
 </head>
 <body>
+{% include "_flash_messages.html" %}
 <h2>PayPayリンク設定</h2>
 <form method="post" action="{{ url_for('admin_settings') }}">
     <label>社会人リンク</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,6 +70,7 @@
         }
     </style>
 
+    {% include "_flash_messages.html" %}
     <h1>参加者一覧</h1>
     <button onclick="location.reload()">🔄 表示を更新</button>
     <p>

--- a/templates/match_form.html
+++ b/templates/match_form.html
@@ -5,6 +5,7 @@
     <title>組み合わせ生成</title>
 </head>
 <body>
+    {% include "_flash_messages.html" %}
     <h1>コート数を指定して組み合わせを生成</h1>
     <form method="post">
         <label>コート数: <input type="number" name="court_count" min="1" required></label>

--- a/templates/register.html
+++ b/templates/register.html
@@ -34,22 +34,6 @@
             border-radius: 6px;
         }
         
-        .flash-messages {
-            list-style: none;
-            padding: 0;
-            margin-bottom: 20px;
-        }
-
-        .flash-messages .error {
-            color: #e74c3c;
-            background-color: #fbeaea;
-            border: 1px solid #e74c3c;
-            padding: 10px;
-            border-radius: 5px;
-            margin-bottom: 10px;
-            text-align: center;
-        }
-
         button {
             margin-top: 30px;
             background-color: #007bff;
@@ -108,15 +92,7 @@
 <body>
     <h1>参加登録フォーム</h1>
     <p>カード: {{ card }}</p>
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            <ul class="flash-messages">
-                {% for category, message in messages %}
-                    <li class="{{ category }}">{{ message }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-    {% endwith %}
+    {% include "_flash_messages.html" %}
     <form method="post" novalidate>
         <input type="hidden" name="card" value="{{ card }}">
         <label>名前:</label>

--- a/tests/test_flash_messages.py
+++ b/tests/test_flash_messages.py
@@ -1,0 +1,87 @@
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+
+def import_app(monkeypatch, tmp_path, config=None):
+    if config is None:
+        config = {
+            "paypay_links": {"adults": "", "students": ""},
+            "level_map": {"beginner": 1, "intermediate": 2, "advanced": 3},
+            "gender_weight": {"male": 1.0, "female": 1.0},
+        }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.setenv("ALLOW_DEV_SECRET_KEY", "1")
+    sys.modules.pop("app", None)
+    return importlib.import_module("app")
+
+
+def test_register_validation_flash_is_rendered(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        app_module,
+        "Participant",
+        SimpleNamespace(query=SimpleNamespace(all=lambda: [])),
+    )
+    client = app_module.app.test_client()
+
+    response = client.post(
+        "/register",
+        data={"name": "", "gender": "male", "level": "beginner", "card": "♥A"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "すべての項目を正しく入力してください" in response.get_data(as_text=True)
+
+
+def test_reset_match_flash_is_rendered_on_match_form(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(app_module, "reset_match_state", lambda: None)
+    client = app_module.app.test_client()
+
+    response = client.post("/reset_match", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert "試合状態をリセットしました" in response.get_data(as_text=True)
+
+
+def test_admin_settings_save_flash_is_rendered(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path)
+    client = app_module.app.test_client()
+
+    response = client.post(
+        "/admin/settings",
+        data={
+            "paypay_adults": "https://example.com/adults",
+            "paypay_students": "https://example.com/students",
+            "level_beginner": "1",
+            "level_intermediate": "2",
+            "level_advanced": "3",
+            "weight_male": "1.0",
+            "weight_female": "1.0",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "設定を保存しました" in response.get_data(as_text=True)
+
+
+def test_reset_db_flash_is_rendered_on_admin_settings(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(app_module, "reset_match_state", lambda: None)
+    monkeypatch.setattr(
+        app_module,
+        "Participant",
+        SimpleNamespace(query=SimpleNamespace(delete=lambda: 0)),
+    )
+    client = app_module.app.test_client()
+
+    response = client.post("/admin/reset_db", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert "参加者データと試合情報をすべて削除しました" in response.get_data(as_text=True)


### PR DESCRIPTION
### Motivation
- Flash messages are emitted from multiple routes (`/register`, `/reset_match`, `/admin/settings`, `/admin/reset_db`) but only `templates/register.html` previously rendered them, causing admin/redirect pages to miss user-visible feedback. 

### Description
- Added a shared partial `templates/_flash_messages.html` that renders `get_flashed_messages(with_categories=true)` with minimal, category-aware styling and accessible attributes.
- Replaced the inline flash block in `templates/register.html` with `{% include "_flash_messages.html" %}` and removed duplicated CSS there.
- Included the shared partial in `templates/index.html`, `templates/admin_settings.html`, and `templates/match_form.html` so redirect targets and admin screens show flash messages.
- Added `tests/test_flash_messages.py` with tests that verify flash output for register validation, `reset_match` redirect, admin settings save, and admin DB reset flows.

### Testing
- Ran the new tests with `pytest tests/test_flash_messages.py` and they passed (4 tests passed).
- Ran the full test suite with `pytest` and all tests passed (45 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348eb2a9348333b7848918ff3032b1)