### PR TITLE
Persist confirmed court_count to match_state for rematches

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,18 @@ def get_draft_court_count(draft):
         return len(matches)
     return 1
 
+
+def get_confirmed_court_count(state):
+    court_count = state.get('court_count')
+    if isinstance(court_count, int) and court_count > 0:
+        return court_count
+
+    matches = state.get('matches')
+    if isinstance(matches, list) and matches:
+        return len(matches)
+
+    return None
+
 def card_to_filename(card):
     if card.startswith('JOKER'):
         return 'joker_red.png' if 'RED' in card else 'joker_black.png'
@@ -297,6 +309,8 @@ def match_form():
         form_value = request.form.get('court_count')
         if form_value:
             court_count = int(form_value)
+        else:
+            court_count = get_confirmed_court_count(state)
 
     if court_count is None:
         # 最初のアクセス or リセット後はフォーム表示
@@ -453,7 +467,7 @@ def confirm_match():
     app.logger.debug(f"[confirm_match] Saving match_state_full: matches={match_ids}, bench={bench_ids}, count={match_count}")
 
     # 確定状態をファイル保存
-    save_match_state_full(True, match_ids, bench_ids, match_count)
+    save_match_state_full(True, match_ids, bench_ids, match_count, court_count=draft.get('court_count'))
 
     # 確定済み state だけを表示の正とするため、未確定 draft を削除する
     clear_draft_state()

--- a/app.py
+++ b/app.py
@@ -327,7 +327,13 @@ def match_form():
     save_draft_state(match_ids, bench_ids, court_count=court_count)
 
     state['match_active'] = True
-    save_match_state_full(state.get('match_active', True), state.get('matches', []), state.get('bench', []), state.get('match_count', 0))
+    save_match_state_full(
+        state.get('match_active', True),
+        state.get('matches', []),
+        state.get('bench', []),
+        state.get('match_count', 0),
+        court_count=court_count,
+    )
 
     
     return redirect(url_for('edit_matches', mode=mode))

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -390,13 +390,17 @@ def configure_confirmation_state(monkeypatch, app_module, initial_state):
     participant_model = SimpleNamespace(id=ParticipantId(), query=ParticipantQuery())
     state = initial_state.copy()
 
-    def save_state(match_active, matches, bench, match_count):
+    def save_state(match_active, matches, bench, match_count, *, court_count=None):
         state.update(
             match_active=match_active,
             matches=matches,
             bench=bench,
             match_count=match_count,
         )
+        if isinstance(court_count, int) and court_count > 0:
+            state["court_count"] = court_count
+        else:
+            state.pop("court_count", None)
 
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
@@ -455,6 +459,125 @@ def test_confirm_match_uses_active_shared_draft_without_session(monkeypatch, tmp
         "match_count": 1,
     }
     assert [player.games_played for player in participants[:5]] == [1, 1, 1, 1, 0]
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_confirm_match_saves_draft_court_count_to_confirmed_state(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    _, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    shared_draft = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "court_count": 3,
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(shared_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/confirm")
+
+    assert response.status_code == 302
+    assert state["court_count"] == 3
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_match_post_without_court_count_uses_confirmed_court_count_after_draft_clear(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 10)]
+    app_module.Participant = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4], [5, 6, 7, 8]],
+            "bench": [9],
+            "match_count": 1,
+            "court_count": 2,
+        },
+    )
+    observed = {}
+
+    def generate(players, courts):
+        observed["courts"] = courts
+        return [players[:4], players[4:8]], players[8:]
+
+    monkeypatch.setattr(app_module, "generate_matches", generate)
+
+    client = app_module.app.test_client()
+    response = client.post("/match")
+
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    assert observed["courts"] == 2
+    assert saved_draft["court_count"] == 2
+    with client.session_transaction() as draft_session:
+        assert "court_count" not in draft_session
+
+
+def test_match_post_without_court_count_falls_back_to_confirmed_match_count_old_schema(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 10)]
+    app_module.Participant = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4], [5, 6, 7, 8]],
+            "bench": [9],
+            "match_count": 1,
+        },
+    )
+    observed = {}
+    monkeypatch.setattr(
+        app_module,
+        "generate_matches",
+        lambda players, courts: (
+            observed.setdefault("courts", courts) and [players[:4], players[4:8]],
+            players[8:],
+        ),
+    )
+
+    response = app_module.app.test_client().post("/match")
+
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 302
+    assert observed["courts"] == 2
+    assert saved_draft["court_count"] == 2
+
+
+def test_match_post_without_court_count_returns_form_when_confirmed_state_has_no_count(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+
+    response = app_module.app.test_client().post("/match")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True))["template"] == "match_form.html"
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_match_post_without_court_count_returns_form_when_confirmed_matches_invalid(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": True, "matches": "invalid", "bench": [], "match_count": 1},
+    )
+
+    response = app_module.app.test_client().post("/match")
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True))["template"] == "match_form.html"
     assert not (tmp_path / "draft_state.json").exists()
 
 

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -23,19 +23,25 @@ def test_creating_draft_preserves_confirmed_matches(monkeypatch, tmp_path):
         "match_count": 3,
     }
     saved_state = []
+    saved_kwargs = []
 
     participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(app_module, "generate_matches", lambda players, courts: ([players[:4]], players[4:]))
     monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
     monkeypatch.setattr(app_module, "save_draft_state", lambda matches, bench, **kwargs: None)
-    monkeypatch.setattr(app_module, "save_match_state_full", lambda *args: saved_state.append(args))
+    def save_state(*args, **kwargs):
+        saved_state.append(args)
+        saved_kwargs.append(kwargs)
+
+    monkeypatch.setattr(app_module, "save_match_state_full", save_state)
 
     client = app_module.app.test_client()
     response = client.post("/match", data={"court_count": "1"})
 
     assert response.status_code == 302
     assert saved_state == [(True, confirmed_matches, [15], 3)]
+    assert saved_kwargs == [{"court_count": 1}]
     with client.session_transaction() as draft_session:
         assert "draft_matches" not in draft_session
         assert "draft_bench" not in draft_session
@@ -74,6 +80,54 @@ def load_test_app(monkeypatch, tmp_path):
         ),
     )
     return app_module
+
+
+def test_rematch_draft_preserves_confirmed_court_count_before_confirmation(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 10)]
+    confirmed_matches = [[1, 2, 3, 4], [5, 6, 7, 8]]
+    confirmed_state = {
+        "match_active": True,
+        "matches": confirmed_matches,
+        "bench": [9],
+        "match_count": 4,
+        "court_count": 2,
+    }
+    saved_state = confirmed_state.copy()
+
+    def save_state(match_active, matches, bench, match_count, *, court_count=None):
+        saved_state.update(
+            match_active=match_active,
+            matches=matches,
+            bench=bench,
+            match_count=match_count,
+        )
+        if isinstance(court_count, int) and court_count > 0:
+            saved_state["court_count"] = court_count
+        else:
+            saved_state.pop("court_count", None)
+
+    participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(app_module, "load_match_state", lambda: saved_state.copy())
+    monkeypatch.setattr(
+        app_module,
+        "generate_matches",
+        lambda players, courts: ([players[:4], players[4:8]], players[8:]),
+    )
+    monkeypatch.setattr(app_module, "save_match_state_full", save_state)
+    client = app_module.app.test_client()
+
+    response = client.post("/match", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert saved_draft["draft"] is True
+    assert saved_draft["court_count"] == 2
+    assert saved_state == confirmed_state
+    with client.session_transaction() as draft_session:
+        assert "court_count" not in draft_session
 
 
 def test_get_draft_court_count_returns_positive_integer(monkeypatch, tmp_path):

--- a/tests/test_match_state.py
+++ b/tests/test_match_state.py
@@ -3,7 +3,7 @@ import json
 from flask import Flask
 
 from routes.api import api_bp
-from utils.match_state import load_match_state, save_match_state
+from utils.match_state import load_match_state, save_match_state, save_match_state_full
 
 
 DEFAULT_MATCH_STATE = {
@@ -40,3 +40,34 @@ def test_match_state_api_uses_shared_default(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     assert response.get_json() == DEFAULT_MATCH_STATE
+
+
+def test_save_match_state_full_accepts_existing_four_argument_calls(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    save_match_state_full(True, [[1, 2, 3, 4]], [5], 2)
+
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert state["match_active"] is True
+    assert state["matches"] == [[1, 2, 3, 4]]
+    assert state["bench"] == [5]
+    assert state["match_count"] == 2
+    assert "court_count" not in state
+
+
+def test_save_match_state_full_saves_positive_int_court_count(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    save_match_state_full(False, [], [], 0, court_count=3)
+
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert state["court_count"] == 3
+
+
+def test_save_match_state_full_ignores_invalid_court_count(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    save_match_state_full(False, [], [], 0, court_count=0)
+
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert "court_count" not in state

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from flask import Flask, session
@@ -45,3 +46,35 @@ def test_reset_clears_shared_match_state_without_managing_confirmed_session_keys
         assert [participant.games_played for participant in participants] == [0, 0]
         assert session["last_confirmed_matches"] == [[9]]
         assert session["last_confirmed_bench"] == [10]
+
+
+def test_reset_match_state_does_not_preserve_court_count(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "match_state.json").write_text(
+        json.dumps(
+            {
+                "match_active": True,
+                "matches": [[1, 2, 3, 4]],
+                "bench": [5],
+                "match_count": 2,
+                "court_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        reset_module,
+        "Participant",
+        SimpleNamespace(query=SimpleNamespace(all=lambda: [])),
+    )
+    monkeypatch.setattr(reset_module.db, "session", SimpleNamespace(commit=lambda: None))
+    monkeypatch.setattr(reset_module, "clear_draft_state", lambda: None)
+
+    reset_module.reset_match_state()
+
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert state["match_active"] is False
+    assert state["matches"] == []
+    assert state["bench"] == []
+    assert state["match_count"] == 0
+    assert "court_count" not in state

--- a/utils/match_state.py
+++ b/utils/match_state.py
@@ -24,7 +24,7 @@ def save_match_state(state):
         json.dump(state, f, ensure_ascii=False, indent=2)
 
 
-def save_match_state_full(match_active, matches, bench, match_count):
+def save_match_state_full(match_active, matches, bench, match_count, *, court_count=None):
     state = {
         "match_active": match_active,
         "match_count": match_count,
@@ -32,4 +32,6 @@ def save_match_state_full(match_active, matches, bench, match_count):
         "bench": bench,
         "timestamp": datetime.now().astimezone().isoformat()
     }
+    if isinstance(court_count, int) and court_count > 0:
+        state["court_count"] = court_count
     save_match_state(state)


### PR DESCRIPTION
### Motivation
- 組み合わせ確定後に「もう一度組み合わせを生成」するとコート数が失われて再度コート数指定画面に戻る不具合を解消するために、確定済み state 側にコート数を保持して再生成時の初期値とする。
- 既存の設計方針（`session` に `court_count` を戻さない、`draft_state.json` の責務を変えない）を守りつつ問題を修正する必要があった。

### Description
- `utils/match_state.py` の `save_match_state_full()` に keyword-only 引数 `court_count=None` を追加し、`isinstance(court_count, int) and court_count > 0` の場合のみ `state["court_count"]` を保存するようにした（既存の4引数呼び出しは互換を維持）。
- 確定済み state から次回生成用のコート数を取得するヘルパー `get_confirmed_court_count(state)` を `app.py` に追加し、`court_count` がない場合は旧 schema 互換で `len(matches)` をフォールバックとして返す実装を追加した。
- `/match` の POST ハンドラで `request.form` に `court_count` がない場合に `get_confirmed_court_count(state)` を使って確定済み `match_state.json` の `court_count`（または旧 schema fallback）を初期値として使うようにし、取得できない場合は従来どおり `match_form.html` を表示するようにした。
- `/match/confirm` で確定時にアクティブな draft の `court_count` を `save_match_state_full(..., court_count=...)` 経由で `match_state.json` に引き継ぐようにした。
- 変更は `session` に `court_count` を保存しない方針を維持し、`draft_state.json` の責務は変更していない。
- 変更対象ファイル: `app.py`, `utils/match_state.py`、およびテスト追加/更新ファイル: `tests/test_match_draft.py`, `tests/test_match_state.py`, `tests/test_reset.py`。

### Testing
- `pytest` を実行して関連テスト群を含む全テストが通過することを確認し、結果は `54 passed`（全テスト成功）であることを確認した。
- `python -m compileall -q app.py utils tests` を実行してコンパイルチェックを行い成功したことを確認した。
- `git diff --check` を実行して差分の問題がないことを確認した。
- 追加・更新した自動テストの内容は、`/match/confirm` で draft の `court_count` が確定 state に保存されること、draft clear 後に `/match` POST（フォームに `court_count` が無い）で確定済み `court_count` を使用して再生成できること、旧 schema（`court_count` が無いが `matches` がある）では `len(matches)` をフォールバックに使うこと、確定 state が空または reset 後は従来どおりフォーム表示に戻ること、`reset_match_state()` 後に `court_count` が残らないことを検証している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34d679808483339a1c84ca4337c79b)