### PR TITLE
Separate confirmed and draft match views under /match and add draft/result routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -498,27 +498,11 @@ def update_court_count():
 
     return redirect(url_for('edit_matches', mode=mode))
 
-@app.route('/match_result')
-def match_result():
-    mode = request.args.get('mode', 'viewer')  # デフォルトは viewer
+def render_match_result_page(match_ids, bench_ids, match_count, mode, *, is_draft, has_draft, has_confirmed):
     participants = {p.id: p for p in Participant.query.all()}
-    draft = get_active_draft()
-    state = load_match_state()
 
-    if draft is None:
-        match_ids = state.get('matches', [])
-        bench_ids = state.get('bench', [])
-    else:
-        match_ids = draft.get('matches', [])
-        bench_ids = draft.get('bench', [])
-
-    # 確定済みの組み合わせ
     matches = [[participants[pid] for pid in group] for group in match_ids]
     bench = [participants[pid] for pid in bench_ids] if bench_ids else []
-
-    match_count = state.get('match_count', 0)
-    if draft is not None:
-        match_count += 1  # draft状態では表示上+1
 
     return render_template(
         'match_result.html',
@@ -527,8 +511,60 @@ def match_result():
         card_to_filename=card_to_filename,
         match_count=match_count,
         mode=mode,
-        is_draft=draft is not None
+        is_draft=is_draft,
+        has_draft=has_draft,
+        has_confirmed=has_confirmed,
     )
+
+
+@app.route('/match/result')
+def match_result():
+    mode = request.args.get('mode', 'viewer')
+    state = load_match_state()
+    draft = get_active_draft()
+    match_ids = state.get('matches', [])
+    bench_ids = state.get('bench', [])
+    has_confirmed = bool(match_ids or bench_ids)
+
+    return render_match_result_page(
+        match_ids,
+        bench_ids,
+        state.get('match_count', 0),
+        mode,
+        is_draft=False,
+        has_draft=draft is not None,
+        has_confirmed=has_confirmed,
+    )
+
+
+@app.route('/match/draft')
+def match_draft():
+    mode = request.args.get('mode', 'viewer')
+    draft = get_active_draft()
+    if draft is None:
+        return redirect(url_for('match_result', mode=mode))
+
+    state = load_match_state()
+    match_ids = draft.get('matches', [])
+    bench_ids = draft.get('bench', [])
+    confirmed_match_ids = state.get('matches', [])
+    confirmed_bench_ids = state.get('bench', [])
+
+    return render_match_result_page(
+        match_ids,
+        bench_ids,
+        state.get('match_count', 0) + 1,
+        mode,
+        is_draft=True,
+        has_draft=True,
+        has_confirmed=bool(confirmed_match_ids or confirmed_bench_ids),
+    )
+
+
+@app.route('/match_result')
+def legacy_match_result():
+    mode = request.args.get('mode', 'viewer')
+    return redirect(url_for('match_result', mode=mode))
 
 @app.route('/reset_match', methods=['POST'])
 def reset_match():

--- a/app.py
+++ b/app.py
@@ -540,6 +540,9 @@ def match_result():
 @app.route('/match/draft')
 def match_draft():
     mode = request.args.get('mode', 'viewer')
+    if mode != 'admin':
+        return redirect(url_for('match_result', mode=mode))
+
     draft = get_active_draft()
     if draft is None:
         return redirect(url_for('match_result', mode=mode))

--- a/app.py
+++ b/app.py
@@ -340,6 +340,10 @@ def match_form():
 
 @app.route('/match/edit')
 def edit_matches():
+    mode = request.args.get('mode', 'admin')
+    if mode != 'admin':
+        return redirect(url_for('match_draft', mode=mode))
+
     draft = get_active_draft()
 
     # 共有中の未確定 draft を表示元の正とする。
@@ -369,7 +373,6 @@ def edit_matches():
 
     court_count = get_draft_court_count(draft)
     match_count = get_match_count()
-    mode = request.args.get('mode', 'viewer')
 
     # config.jsonの読み込み
     with open("config.json", "r", encoding="utf-8") as f:
@@ -540,9 +543,6 @@ def match_result():
 @app.route('/match/draft')
 def match_draft():
     mode = request.args.get('mode', 'viewer')
-    if mode != 'admin':
-        return redirect(url_for('match_result', mode=mode))
-
     draft = get_active_draft()
     if draft is None:
         return redirect(url_for('match_result', mode=mode))

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,7 +79,7 @@
                 <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
             {% endif %}
             {% if has_draft %}
-                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
+                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 次の組み合わせ(編集中)を表示</a>
                 <form method="get" action="{{ url_for('edit_matches') }}">
                     <input type="hidden" name="mode" value="{{ mode }}">
                     <button type="submit">✏️ 編集に戻る</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,14 +75,17 @@
     <button onclick="location.reload()">🔄 表示を更新</button>
     <p>
         {% if mode == 'admin' %}
+            {% if has_confirmed %}
+                <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
+            {% endif %}
             {% if has_draft %}
+                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
                 <form method="get" action="{{ url_for('edit_matches') }}">
                     <input type="hidden" name="mode" value="{{ mode }}">
                     <button type="submit">✏️ 編集に戻る</button>
                 </form>
-            {% elif has_confirmed %}
-                <a href="{{ url_for('match_result', mode=mode) }}">▶ 現在の組み合わせを表示</a>
-            {% else %}
+            {% endif %}
+            {% if not has_confirmed and not has_draft %}
                 <form method="post" action="{{ url_for('match_form') }}">
                     <!--<input type="hidden" name="court_count" value="3">-->
                     <input type="hidden" name="mode" value="admin">

--- a/templates/match_edit.html
+++ b/templates/match_edit.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>仮組み合わせ</title>
+    <title>次の組み合わせ(編集中)</title>
 </head>
 <body>
 
@@ -67,7 +67,7 @@
     }
 </style>
 
-<h1>仮組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
+<h1>次の組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
 
 <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
     <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>

--- a/templates/match_edit.html
+++ b/templates/match_edit.html
@@ -69,6 +69,10 @@
 
 <h1>仮組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
 
+<nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
+    <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
+</nav>
+
 <form id="swap-form" action="{{ url_for('swap_players') }}" method="post">
     <input type="hidden" name="mode" value="{{ mode }}">
     <input type="hidden" name="swap_ids" id="swap-ids">

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -75,7 +75,7 @@
     <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
         {% if not is_draft and has_draft %}
             {% if mode == 'admin' %}
-                <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせ(編集中)を編集</a>
+                <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせを編集</a>
             {% else %}
                 <a href="{{ url_for('match_draft', mode=mode) }}">▶ 次の組み合わせ(編集中)を表示</a>
             {% endif %}
@@ -84,7 +84,7 @@
             <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
         {% endif %}
         {% if is_draft and mode == 'admin' %}
-            <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせ(編集中)を編集</a>
+            <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせを編集</a>
         {% endif %}
     </nav>
 

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -64,7 +64,7 @@
         }
     </style>
     {% if is_draft %}
-        <h1>仮組み合わせ ■ {{ match_count }} 回目</h1>
+        <h1>次の組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
         <div style="background-color: #fff3cd; color: #856404; padding: 12px; border-radius: 6px; border: 1px solid #ffeeba; font-weight: bold; margin-bottom: 12px;">
             ⚠️ この組み合わせはまだ確定していません（編集中）
         </div>
@@ -75,16 +75,16 @@
     <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
         {% if not is_draft and has_draft %}
             {% if mode == 'admin' %}
-                <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 仮組み合わせを編集</a>
+                <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせ(編集中)を編集</a>
             {% else %}
-                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
+                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 次の組み合わせ(編集中)を表示</a>
             {% endif %}
         {% endif %}
         {% if is_draft %}
             <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
         {% endif %}
         {% if is_draft and mode == 'admin' %}
-            <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 仮組み合わせを編集</a>
+            <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 次の組み合わせ(編集中)を編集</a>
         {% endif %}
     </nav>
 

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -64,12 +64,26 @@
         }
     </style>
     {% if is_draft %}
+        <h1>仮組み合わせ ■ {{ match_count }} 回目</h1>
         <div style="background-color: #fff3cd; color: #856404; padding: 12px; border-radius: 6px; border: 1px solid #ffeeba; font-weight: bold; margin-bottom: 12px;">
             ⚠️ この組み合わせはまだ確定していません（編集中）
         </div>
     {% else %}
-        <h1>組み合わせ結果 ■ {{ match_count }} 回目</h1>
+        <h1>確定済み組み合わせ ■ {{ match_count }} 回目</h1>
     {% endif %}
+
+    <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
+        {% if not is_draft and has_draft %}
+            <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
+        {% endif %}
+        {% if is_draft and has_confirmed %}
+            <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
+        {% endif %}
+        {% if is_draft and mode == 'admin' %}
+            <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 仮組み合わせを編集</a>
+        {% endif %}
+    </nav>
+
     <button onclick="location.reload()">🔄 表示を更新</button>
 
     <div style="display: flex; flex-wrap: wrap; gap: 20px;">

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -73,10 +73,14 @@
     {% endif %}
 
     <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
-        {% if mode == 'admin' and not is_draft and has_draft %}
-            <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
+        {% if not is_draft and has_draft %}
+            {% if mode == 'admin' %}
+                <a href="{{ url_for('edit_matches', mode=mode) }}">✏️ 仮組み合わせを編集</a>
+            {% else %}
+                <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
+            {% endif %}
         {% endif %}
-        {% if is_draft and has_confirmed %}
+        {% if is_draft %}
             <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
         {% endif %}
         {% if is_draft and mode == 'admin' %}
@@ -129,10 +133,12 @@
     {% endif %}
     
     {% if mode == 'admin' %}
-        <form action="{{ url_for('match_form') }}" method="post">
-            <input type="hidden" name="mode" value="{{ mode }}">
-            <button type="submit">もう一度組み合わせを生成</button>
-        </form>
+        {% if not has_draft %}
+            <form action="{{ url_for('match_form') }}" method="post">
+                <input type="hidden" name="mode" value="{{ mode }}">
+                <button type="submit">もう一度組み合わせを生成</button>
+            </form>
+        {% endif %}
     
         <form action="{{ url_for('reset_match') }}" method="post">
             <input type="hidden" name="mode" value="{{ mode }}">

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -73,7 +73,7 @@
     {% endif %}
 
     <nav style="display: flex; flex-wrap: wrap; gap: 12px; margin: 12px 0;">
-        {% if not is_draft and has_draft %}
+        {% if mode == 'admin' and not is_draft and has_draft %}
             <a href="{{ url_for('match_draft', mode=mode) }}">▶ 仮組み合わせを表示</a>
         {% endif %}
         {% if is_draft and has_confirmed %}

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -716,7 +716,7 @@ def test_match_result_and_draft_routes_use_separate_state(monkeypatch, tmp_path)
 
     client = app_module.app.test_client()
     result_response = client.get("/match/result")
-    draft_response = client.get("/match/draft")
+    draft_response = client.get("/match/draft?mode=admin")
 
     assert result_response.status_code == 200
     assert json.loads(result_response.get_data(as_text=True)) == {
@@ -738,6 +738,50 @@ def test_match_result_and_draft_routes_use_separate_state(monkeypatch, tmp_path)
         "has_confirmed": True,
         "is_draft": True,
     }
+
+
+def test_viewer_match_result_hides_active_draft_link(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
+        participant.games_played = participant.id
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4]],
+            "bench": [5],
+            "match_count": 3,
+        },
+    )
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+
+    response = app_module.app.test_client().get("/match/result?mode=viewer")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "/match/draft" not in html
+    assert "仮組み合わせを表示" not in html
+    assert "確定済み組み合わせ" in html
+
+
+def test_viewer_match_draft_redirects_to_result_without_showing_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().get("/match/draft?mode=viewer")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/result?mode=viewer")
 
 
 def test_match_draft_redirects_to_result_without_active_draft(monkeypatch, tmp_path):

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import sys
+from flask import render_template as flask_render_template
 from types import SimpleNamespace
 
 
@@ -480,7 +481,7 @@ def test_confirm_match_prefers_active_shared_draft_over_session_draft(monkeypatc
     response = client.post("/match/confirm", data={"mode": "admin"})
 
     assert response.status_code == 302
-    assert response.headers["Location"].endswith("/match_result?mode=admin")
+    assert response.headers["Location"].endswith("/match/result?mode=admin")
     assert state == {
         "match_active": True,
         "matches": shared_draft["matches"],
@@ -686,12 +687,118 @@ def test_match_result_uses_confirmed_match_state_after_confirmation(monkeypatch,
     assert not (tmp_path / "draft_state.json").exists()
 
 
+def test_match_result_and_draft_routes_use_separate_state(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    confirmed_state = {
+        "match_active": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "match_count": 7,
+    }
+    draft_state = {"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft_state), encoding="utf-8")
+    monkeypatch.setattr(app_module, "load_match_state", lambda: confirmed_state.copy())
+    monkeypatch.setattr(
+        app_module,
+        "render_template",
+        lambda template, **context: json.dumps(
+            {
+                "template": template,
+                "matches": [[player.id for player in group] for group in context["matches"]],
+                "bench": [player.id for player in context["bench"]],
+                "match_count": context["match_count"],
+                "has_draft": context["has_draft"],
+                "has_confirmed": context["has_confirmed"],
+                "is_draft": context["is_draft"],
+            }
+        ),
+    )
+
+    client = app_module.app.test_client()
+    result_response = client.get("/match/result")
+    draft_response = client.get("/match/draft")
+
+    assert result_response.status_code == 200
+    assert json.loads(result_response.get_data(as_text=True)) == {
+        "template": "match_result.html",
+        "matches": confirmed_state["matches"],
+        "bench": confirmed_state["bench"],
+        "match_count": 7,
+        "has_draft": True,
+        "has_confirmed": True,
+        "is_draft": False,
+    }
+    assert draft_response.status_code == 200
+    assert json.loads(draft_response.get_data(as_text=True)) == {
+        "template": "match_result.html",
+        "matches": draft_state["matches"],
+        "bench": draft_state["bench"],
+        "match_count": 8,
+        "has_draft": True,
+        "has_confirmed": True,
+        "is_draft": True,
+    }
+
+
+def test_match_draft_redirects_to_result_without_active_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+
+    response = app_module.app.test_client().get("/match/draft?mode=admin")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/result?mode=admin")
+
+
+def test_legacy_match_result_redirects_to_match_result(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+
+    response = app_module.app.test_client().get("/match_result?mode=admin")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/result?mode=admin")
+
+
+def test_admin_index_shows_confirmed_and_draft_links(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    app_module.Participant.card = object()
+    app_module.Participant.query.order_by = lambda _: app_module.Participant.query
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[5, 6, 7, 8]],
+            "bench": [9],
+            "match_count": 3,
+        },
+    )
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+    client = app_module.app.test_client()
+
+    response = client.get("/admin")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "/match/result?mode=admin" in html
+    assert "/match/draft?mode=admin" in html
+    assert "確定済み組み合わせ" in html
+    assert "仮組み合わせ" in html
+
+
 def test_admin_ignores_stale_confirmed_session_when_shared_state_is_empty(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     app_module.Participant.card = object()
     app_module.Participant.query.order_by = lambda _: app_module.Participant.query
-    for participant in app_module.Participant.query.all():
-        participant.card = f"card-{participant.id}"
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
     monkeypatch.setattr(
         app_module,
         "load_match_state",
@@ -726,8 +833,9 @@ def test_admin_has_confirmed_when_shared_match_state_has_results(monkeypatch, tm
     app_module = load_test_app(monkeypatch, tmp_path)
     app_module.Participant.card = object()
     app_module.Participant.query.order_by = lambda _: app_module.Participant.query
-    for participant in app_module.Participant.query.all():
-        participant.card = f"card-{participant.id}"
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
     monkeypatch.setattr(
         app_module,
         "load_match_state",

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -740,7 +740,7 @@ def test_match_result_and_draft_routes_use_separate_state(monkeypatch, tmp_path)
     }
 
 
-def test_viewer_match_result_hides_active_draft_link(monkeypatch, tmp_path):
+def test_viewer_match_result_shows_active_draft_link(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
         participant.card = card
@@ -766,22 +766,96 @@ def test_viewer_match_result_hides_active_draft_link(monkeypatch, tmp_path):
     html = response.get_data(as_text=True)
 
     assert response.status_code == 200
-    assert "/match/draft" not in html
-    assert "仮組み合わせを表示" not in html
+    assert "/match/draft?mode=viewer" in html
+    assert "/match/edit" not in html
+    assert "仮組み合わせを表示" in html
     assert "確定済み組み合わせ" in html
 
 
-def test_viewer_match_draft_redirects_to_result_without_showing_draft(monkeypatch, tmp_path):
+def test_viewer_match_draft_shows_active_draft_without_redirect(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     (tmp_path / "draft_state.json").write_text(
         json.dumps({"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}),
         encoding="utf-8",
     )
 
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"draft-player-{participant.id}"
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+
     response = app_module.app.test_client().get("/match/draft?mode=viewer")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "仮組み合わせ" in html
+    assert "draft-player-2" in html
+    assert "/match/result?mode=viewer" in html
+    assert "/match/edit" not in html
+    assert "この組み合わせを確定する" not in html
+    assert "もう一度組み合わせを生成" not in html
+
+
+def test_viewer_match_edit_redirects_to_viewer_draft(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().get("/match/edit?mode=viewer")
 
     assert response.status_code == 302
-    assert response.headers["Location"].endswith("/match/result?mode=viewer")
+    assert response.headers["Location"].endswith("/match/draft?mode=viewer")
+
+
+def test_admin_match_result_links_to_edit_not_draft_and_hides_rematch(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4]],
+            "bench": [5],
+            "match_count": 3,
+        },
+    )
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+
+    response = app_module.app.test_client().get("/match/result?mode=admin")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "/match/edit?mode=admin" in html
+    assert "/match/draft?mode=admin" not in html
+    assert "もう一度組み合わせを生成" not in html
+
+
+def test_admin_draft_hides_rematch_and_links_to_edit(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[2, 3, 4, 5]], "bench": [1]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+
+    response = app_module.app.test_client().get("/match/draft?mode=admin")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "/match/edit?mode=admin" in html
+    assert "もう一度組み合わせを生成" not in html
 
 
 def test_match_draft_redirects_to_result_without_active_draft(monkeypatch, tmp_path):

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -768,7 +768,7 @@ def test_viewer_match_result_shows_active_draft_link(monkeypatch, tmp_path):
     assert response.status_code == 200
     assert "/match/draft?mode=viewer" in html
     assert "/match/edit" not in html
-    assert "仮組み合わせを表示" in html
+    assert "次の組み合わせ(編集中)を表示" in html
     assert "確定済み組み合わせ" in html
 
 
@@ -788,7 +788,7 @@ def test_viewer_match_draft_shows_active_draft_without_redirect(monkeypatch, tmp
     html = response.get_data(as_text=True)
 
     assert response.status_code == 200
-    assert "仮組み合わせ" in html
+    assert "次の組み合わせ(編集中)" in html
     assert "draft-player-2" in html
     assert "/match/result?mode=viewer" in html
     assert "/match/edit" not in html
@@ -907,7 +907,7 @@ def test_admin_index_shows_confirmed_and_draft_links(monkeypatch, tmp_path):
     assert "/match/result?mode=admin" in html
     assert "/match/draft?mode=admin" in html
     assert "確定済み組み合わせ" in html
-    assert "仮組み合わせ" in html
+    assert "次の組み合わせ(編集中)" in html
 
 
 def test_admin_ignores_stale_confirmed_session_when_shared_state_is_empty(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- The existing `/match_result` endpoint could show an active shared draft (`draft_state.json`) instead of the confirmed `match_state.json`, causing confusion between confirmed and draft displays. The goal is to separate responsibilities so confirmed results and drafts are displayed on distinct URLs under `/match` while keeping backward compatibility.

### Description
- Add a reusable renderer `render_match_result_page` and new routes `GET /match/result` (always uses `match_state.json`) and `GET /match/draft` (renders active draft from `get_active_draft()`), and preserve `GET /match_result` as a legacy redirect to `/match/result` while preserving the `mode` query parameter.
- Ensure `match_count` semantics: `/match/result` shows the confirmed `match_count` from `match_state.json`, and `/match/draft` shows `confirmed_match_count + 1` for display.
- Update `templates/match_result.html` to show distinct headings for confirmed vs draft, to display a draft warning, and to provide cross-links between confirmed and draft pages and an edit link on admin draft pages; pass `is_draft`, `has_draft`, and `has_confirmed` into the template.
- Update `templates/index.html` admin navigation so both confirmed and draft links are shown when both states exist, with viewer behavior unchanged.
- Add/adjust regression tests in `tests/test_match_draft.py` to cover route separation, redirects, `match_count` behavior, template flags, and admin navigation (new tests: `test_match_result_and_draft_routes_use_separate_state`, `test_match_draft_redirects_to_result_without_active_draft`, `test_legacy_match_result_redirects_to_match_result`, `test_admin_index_shows_confirmed_and_draft_links`) and update expectations that previously targeted `/match_result` to use `/match/result`.

### Testing
- Ran the full test suite with `pytest`, and all tests passed: `59 passed`.
- The added/modified tests specifically exercise confirmed vs draft rendering, redirect behavior, template context flags, and admin index navigation and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a13097ab4833388238dfc52e773bc)