### PR TITLE
Add admin action to revert confirmed matches back to draft

### DIFF
--- a/app.py
+++ b/app.py
@@ -484,6 +484,44 @@ def confirm_match():
     mode = request.form.get('mode', 'viewer')
     return redirect(url_for('match_result', mode=mode))
 
+
+@app.route('/match/revert_to_draft', methods=['POST'])
+def revert_match_to_draft():
+    mode = request.form.get('mode', request.args.get('mode', 'admin'))
+    if mode == 'viewer':
+        return redirect(url_for('match_result', mode='viewer'))
+
+    state = load_match_state()
+    match_ids = state.get('matches', [])
+    bench_ids = state.get('bench', [])
+    if not (match_ids or bench_ids):
+        flash('確定済み組み合わせがありません')
+        return redirect(url_for('match_result', mode='admin'))
+
+    save_draft_state(
+        match_ids,
+        bench_ids,
+        court_count=state.get('court_count'),
+    )
+
+    confirmed_ids = {pid for group in match_ids for pid in group}
+    if confirmed_ids:
+        for participant in Participant.query.filter(Participant.id.in_(confirmed_ids)).all():
+            participant.games_played = max((participant.games_played or 0) - 1, 0)
+        db.session.commit()
+
+    match_count = max(state.get('match_count', 0) - 1, 0)
+    save_match_state_full(
+        False,
+        [],
+        [],
+        match_count,
+        court_count=state.get('court_count'),
+    )
+
+    return redirect(url_for('edit_matches', mode='admin'))
+
+
 @app.route('/update_court_count', methods=['POST'])
 def update_court_count():
     new_count = int(request.form['court_count'])

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -88,13 +88,6 @@
         {% endif %}
     </nav>
 
-    {% if mode == 'admin' and not is_draft and has_confirmed %}
-        <form method="post" action="{{ url_for('revert_match_to_draft') }}" style="margin: 12px 0;">
-            <input type="hidden" name="mode" value="admin">
-            <button type="submit">確定を取り消して編集に戻す</button>
-        </form>
-    {% endif %}
-
     <button onclick="location.reload()">🔄 表示を更新</button>
 
     <div style="display: flex; flex-wrap: wrap; gap: 20px;">
@@ -144,6 +137,12 @@
             <form action="{{ url_for('match_form') }}" method="post">
                 <input type="hidden" name="mode" value="{{ mode }}">
                 <button type="submit">もう一度組み合わせを生成</button>
+            </form>
+        {% endif %}
+        {% if not is_draft and has_confirmed %}
+            <form method="post" action="{{ url_for('revert_match_to_draft') }}" style="margin: 12px 0;">
+                <input type="hidden" name="mode" value="admin">
+                <button type="submit">確定を取り消して編集に戻す</button>
             </form>
         {% endif %}
     

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -88,6 +88,13 @@
         {% endif %}
     </nav>
 
+    {% if mode == 'admin' and not is_draft and has_confirmed %}
+        <form method="post" action="{{ url_for('revert_match_to_draft') }}" style="margin: 12px 0;">
+            <input type="hidden" name="mode" value="admin">
+            <button type="submit">確定を取り消して編集に戻す</button>
+        </form>
+    {% endif %}
+
     <button onclick="location.reload()">🔄 表示を更新</button>
 
     <div style="display: flex; flex-wrap: wrap; gap: 20px;">

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -976,6 +976,33 @@ def test_admin_match_result_links_to_edit_not_draft_and_hides_rematch(monkeypatc
     assert 'action="/match/revert_to_draft"' in html
 
 
+def test_admin_match_result_places_revert_below_rematch(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):
+        participant.card = card
+        participant.name = f"player-{participant.id}"
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {
+            "match_active": True,
+            "matches": [[1, 2, 3, 4]],
+            "bench": [5],
+            "match_count": 3,
+        },
+    )
+    monkeypatch.setattr(app_module, "render_template", flask_render_template)
+
+    response = app_module.app.test_client().get("/match/result?mode=admin")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    rematch_index = html.index("もう一度組み合わせを生成")
+    revert_index = html.index("確定を取り消して編集に戻す")
+    assert rematch_index < revert_index
+    assert 'action="/match/revert_to_draft"' in html
+
+
 def test_admin_draft_hides_rematch_and_links_to_edit(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     for participant, card in zip(app_module.Participant.query.all(), ["♥A", "♥2", "♥3", "♥4", "♥5"]):

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -83,6 +83,53 @@ def load_test_app(monkeypatch, tmp_path):
     return app_module
 
 
+def load_db_test_app(monkeypatch, tmp_path):
+    config = {
+        "level_map": {},
+        "gender_weight": {},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    app_module.app.config["TESTING"] = True
+    participants = [
+        SimpleNamespace(id=player_id, games_played=games_played)
+        for player_id, games_played in enumerate([2, 1, 0, 3, 4], start=1)
+    ]
+
+    class IdField:
+        @staticmethod
+        def in_(ids):
+            return set(ids)
+
+    class ParticipantQuery:
+        def __init__(self, players):
+            self.players = players
+            self.selected_ids = None
+
+        def filter(self, selected_ids):
+            query = ParticipantQuery(self.players)
+            query.selected_ids = selected_ids
+            return query
+
+        def all(self):
+            if self.selected_ids is None:
+                return list(self.players)
+            return [player for player in self.players if player.id in self.selected_ids]
+
+        def order_by(self, _):
+            return self
+
+        def get(self, player_id):
+            return next(player for player in self.players if player.id == player_id)
+
+    participant_model = SimpleNamespace(id=IdField(), query=ParticipantQuery(participants))
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(commit=lambda: None, remove=lambda: None))
+    return app_module
+
+
 def test_rematch_draft_preserves_confirmed_court_count_before_confirmation(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     participants = [SimpleNamespace(id=player_id) for player_id in range(1, 10)]
@@ -539,6 +586,93 @@ def test_confirm_match_saves_draft_court_count_to_confirmed_state(monkeypatch, t
     assert not (tmp_path / "draft_state.json").exists()
 
 
+def test_revert_match_to_draft_overwrites_draft_and_clears_confirmed_state(monkeypatch, tmp_path):
+    app_module = load_db_test_app(monkeypatch, tmp_path)
+    confirmed_state = {
+        "match_active": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "match_count": 2,
+        "court_count": 1,
+    }
+    (tmp_path / "match_state.json").write_text(json.dumps(confirmed_state), encoding="utf-8")
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[5, 4, 3, 2]], "bench": [1], "court_count": 1}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().post("/match/revert_to_draft", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    saved_draft = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert saved_draft["draft"] is True
+    assert saved_draft["matches"] == confirmed_state["matches"]
+    assert saved_draft["bench"] == confirmed_state["bench"]
+    assert saved_draft["court_count"] == confirmed_state["court_count"]
+    saved_state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert saved_state["match_active"] is False
+    assert saved_state["matches"] == []
+    assert saved_state["bench"] == []
+    assert saved_state["match_count"] == 1
+    assert saved_state["court_count"] == 1
+    with app_module.app.app_context():
+        games_played_by_id = {
+            participant.id: participant.games_played
+            for participant in app_module.Participant.query.order_by(app_module.Participant.id).all()
+        }
+    assert games_played_by_id == {1: 1, 2: 0, 3: 0, 4: 2, 5: 4}
+
+
+def test_revert_match_to_draft_does_not_make_counts_negative(monkeypatch, tmp_path):
+    app_module = load_db_test_app(monkeypatch, tmp_path)
+    (tmp_path / "match_state.json").write_text(
+        json.dumps({"match_active": True, "matches": [[2, 3]], "bench": [], "match_count": 0}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().post("/match/revert_to_draft", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    saved_state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert saved_state["match_count"] == 0
+    with app_module.app.app_context():
+        assert app_module.Participant.query.get(2).games_played == 0
+        assert app_module.Participant.query.get(3).games_played == 0
+
+
+def test_revert_match_to_draft_viewer_redirects_without_changing_draft(monkeypatch, tmp_path):
+    app_module = load_db_test_app(monkeypatch, tmp_path)
+    original_draft = {"draft": True, "matches": [[5, 4, 3, 2]], "bench": [1], "court_count": 1}
+    (tmp_path / "match_state.json").write_text(
+        json.dumps({"match_active": True, "matches": [[1, 2, 3, 4]], "bench": [5], "match_count": 2}),
+        encoding="utf-8",
+    )
+    (tmp_path / "draft_state.json").write_text(json.dumps(original_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/revert_to_draft", data={"mode": "viewer"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/result?mode=viewer")
+    assert json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8")) == original_draft
+
+
+def test_revert_match_to_draft_without_confirmed_match_keeps_draft(monkeypatch, tmp_path):
+    app_module = load_db_test_app(monkeypatch, tmp_path)
+    original_draft = {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]}
+    (tmp_path / "match_state.json").write_text(
+        json.dumps({"match_active": False, "matches": [], "bench": [], "match_count": 0}),
+        encoding="utf-8",
+    )
+    (tmp_path / "draft_state.json").write_text(json.dumps(original_draft), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/revert_to_draft", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/result?mode=admin")
+    assert json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8")) == original_draft
+
+
 def test_match_post_without_court_count_uses_confirmed_court_count_after_draft_clear(monkeypatch, tmp_path):
     app_module = load_test_app(monkeypatch, tmp_path)
     participants = [SimpleNamespace(id=player_id) for player_id in range(1, 10)]
@@ -770,6 +904,7 @@ def test_viewer_match_result_shows_active_draft_link(monkeypatch, tmp_path):
     assert "/match/edit" not in html
     assert "次の組み合わせ(編集中)を表示" in html
     assert "確定済み組み合わせ" in html
+    assert "確定を取り消して編集に戻す" not in html
 
 
 def test_viewer_match_draft_shows_active_draft_without_redirect(monkeypatch, tmp_path):
@@ -837,6 +972,8 @@ def test_admin_match_result_links_to_edit_not_draft_and_hides_rematch(monkeypatc
     assert "/match/edit?mode=admin" in html
     assert "/match/draft?mode=admin" not in html
     assert "もう一度組み合わせを生成" not in html
+    assert "確定を取り消して編集に戻す" in html
+    assert 'action="/match/revert_to_draft"' in html
 
 
 def test_admin_draft_hides_rematch_and_links_to_edit(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Administrators need the ability to take a previously confirmed match state and return it to the editable draft so they can adjust pairings after confirmation.
- Reverting should also undo side-effects from confirmation: decrement `games_played` for players who were matched and decrement the global `match_count` without making counts negative.

### Description
- Added a new admin-only POST route `POST /match/revert_to_draft` implemented as `revert_match_to_draft()` in `app.py` that copies `matches`, `bench`, and `court_count` from `match_state.json` into `draft_state.json` and redirects to `edit_matches` for admin users.
- The route decrements `games_played` by 1 for participants who were in `matches` (bench players are not changed) while clamping values at `0`, then decrements `match_count` by 1 while clamping at `0`, and clears the confirmed `matches`/`bench` and sets `match_active=False` in `match_state.json` via `save_match_state_full()`.
- Viewer-mode requests are blocked from performing the revert: when `mode=='viewer'` the handler immediately redirects to `match_result?mode=viewer` and does not change draft state.
- Added a POST button to `templates/match_result.html` (visible only when `mode=='admin' and not is_draft and has_confirmed`) with the label `確定を取り消して編集に戻す` that submits to `/match/revert_to_draft`.
- Extended `tests/test_match_draft.py` with a test helper `load_db_test_app()` (mocking participant query/session behavior) and added tests that cover: draft overwrite, confirmed-state clearing, `games_played` rollback (non-negative), `match_count` decrement (non-negative), viewer protection, and behavior when there is no confirmed match.

### Testing
- Ran the modified file tests: `pytest tests/test_match_draft.py` and observed all tests in that file pass (`42 passed`).
- Ran the full test suite with `pytest` and observed `68 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a3d705d308333bbf8f5f5c4d243a1)