### PR TITLE
確定済み試合の履歴保存を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import io
 import logging
 from io import TextIOWrapper
 from flask import Flask, render_template, request, redirect, url_for, abort
-from models import db, Participant 
+from models import db, Participant, MatchRound, MatchHistory, BenchHistory
 # from flask_sqlalchemy import SQLAlchemy
 from flask import flash
 from flask import Response
@@ -459,6 +459,30 @@ def confirm_match():
     match_ids = draft['matches']
     bench_ids = draft['bench']
 
+    # 組み合わせ回数カウントアップ
+    state = load_match_state()
+    match_count = state.get('match_count', 0) + 1
+
+    match_round = MatchRound(round_number=match_count)
+    db.session.add(match_round)
+    db.session.flush()
+
+    for court_number, group in enumerate(match_ids, start=1):
+        db.session.add(MatchHistory(
+            round_id=match_round.id,
+            court_number=court_number,
+            team1_player1_id=group[0],
+            team1_player2_id=group[1],
+            team2_player1_id=group[2],
+            team2_player2_id=group[3],
+        ))
+
+    for participant_id in bench_ids:
+        db.session.add(BenchHistory(
+            round_id=match_round.id,
+            participant_id=participant_id,
+        ))
+
     # 対象参加者IDを集める
     confirmed_ids = [pid for group in match_ids for pid in group]
 
@@ -467,10 +491,6 @@ def confirm_match():
         p.games_played += 1
 
     db.session.commit()
-
-    # 組み合わせ回数カウントアップ
-    state = load_match_state()
-    match_count = state.get('match_count', 0) + 1
 
     # ワーカー切替時のセッション消失問題の調査用ログ（2025/10 対応）
     app.logger.debug(f"[confirm_match] Saving match_state_full: matches={match_ids}, bench={bench_ids}, count={match_count}")
@@ -648,7 +668,11 @@ def admin_settings():
 def reset_db():
     # 先にマッチ状態をリセット
     reset_match_state()
-    # その後で参加者データをすべて削除
+    db.create_all()
+    # その後で履歴と参加者データをすべて削除
+    BenchHistory.query.delete()
+    MatchHistory.query.delete()
+    MatchRound.query.delete()
     Participant.query.delete()
     db.session.commit()
     flash('参加者データと試合情報をすべて削除しました')

--- a/app.py
+++ b/app.py
@@ -54,6 +54,16 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(app.instance
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 # モデル側のdbをアプリに紐づけ
 db.init_app(app)
+
+
+def ensure_database_tables():
+    """Create any missing tables for the configured application database."""
+    os.makedirs(app.instance_path, exist_ok=True)
+    with app.app_context():
+        db.create_all()
+
+
+ensure_database_tables()
 app.register_blueprint(api_bp)
 
 ALL_CARDS = [
@@ -490,16 +500,20 @@ def confirm_match():
     for p in Participant.query.filter(Participant.id.in_(confirmed_ids)).all():
         p.games_played += 1
 
-    db.session.commit()
-
     # ワーカー切替時のセッション消失問題の調査用ログ（2025/10 対応）
     app.logger.debug(f"[confirm_match] Saving match_state_full: matches={match_ids}, bench={bench_ids}, count={match_count}")
 
-    # 確定状態をファイル保存
-    save_match_state_full(True, match_ids, bench_ids, match_count, court_count=draft.get('court_count'))
+    try:
+        # 確定状態をファイル保存
+        save_match_state_full(True, match_ids, bench_ids, match_count, court_count=draft.get('court_count'))
 
-    # 確定済み state だけを表示の正とするため、未確定 draft を削除する
-    clear_draft_state()
+        # 確定済み state だけを表示の正とするため、未確定 draft を削除する
+        clear_draft_state()
+
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
 
     mode = request.form.get('mode', 'viewer')
     return redirect(url_for('match_result', mode=mode))
@@ -528,9 +542,23 @@ def revert_match_to_draft():
     if confirmed_ids:
         for participant in Participant.query.filter(Participant.id.in_(confirmed_ids)).all():
             participant.games_played = max((participant.games_played or 0) - 1, 0)
-        db.session.commit()
 
-    match_count = max(state.get('match_count', 0) - 1, 0)
+    current_match_count = state.get('match_count', 0)
+    match_round = (
+        MatchRound.query
+        .filter_by(round_number=current_match_count)
+        .order_by(MatchRound.id.desc())
+        .first()
+    )
+
+    if match_round is not None:
+        BenchHistory.query.filter_by(round_id=match_round.id).delete(synchronize_session=False)
+        MatchHistory.query.filter_by(round_id=match_round.id).delete(synchronize_session=False)
+        db.session.delete(match_round)
+
+    db.session.commit()
+
+    match_count = max(current_match_count - 1, 0)
     save_match_state_full(
         False,
         [],
@@ -689,6 +717,5 @@ def viewer_index():
     return render_index_view(mode='viewer')
 
 if __name__ == '__main__':
-    with app.app_context():
-        db.create_all()
+    ensure_database_tables()
     app.run(debug=True, host='0.0.0.0', port=5001)

--- a/init_db.py
+++ b/init_db.py
@@ -1,5 +1,4 @@
-import os
-from app import app, db
+from app import ensure_database_tables
 
-with app.app_context():
-    os.makedirs(app.instance_path, exist_ok=True)
+
+ensure_database_tables()

--- a/models.py
+++ b/models.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timezone
+
 from flask_sqlalchemy import SQLAlchemy
 
+
 db = SQLAlchemy()
+
 
 class Participant(db.Model):
     __tablename__ = 'participants'
@@ -12,3 +16,40 @@ class Participant(db.Model):
     games_played = db.Column(db.Integer, default=0)
     active = db.Column(db.Boolean, default=True)
     card = db.Column(db.String(10), unique=True, nullable=False)
+
+
+class MatchRound(db.Model):
+    __tablename__ = 'match_rounds'
+    id = db.Column(db.Integer, primary_key=True)
+    round_number = db.Column(db.Integer, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    matches = db.relationship(
+        'MatchHistory', backref='round', cascade='all, delete-orphan', lazy=True
+    )
+    bench_players = db.relationship(
+        'BenchHistory', backref='round', cascade='all, delete-orphan', lazy=True
+    )
+
+
+class MatchHistory(db.Model):
+    __tablename__ = 'match_histories'
+    id = db.Column(db.Integer, primary_key=True)
+    round_id = db.Column(db.Integer, db.ForeignKey('match_rounds.id'), nullable=False)
+    court_number = db.Column(db.Integer, nullable=False)
+    team1_player1_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
+    team1_player2_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
+    team2_player1_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
+    team2_player2_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
+    team1_score = db.Column(db.Integer, nullable=True)
+    team2_score = db.Column(db.Integer, nullable=True)
+    winner_team = db.Column(db.Integer, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+
+
+class BenchHistory(db.Model):
+    __tablename__ = 'bench_histories'
+    id = db.Column(db.Integer, primary_key=True)
+    round_id = db.Column(db.Integer, db.ForeignKey('match_rounds.id'), nullable=False)
+    participant_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -124,9 +124,20 @@ def load_db_test_app(monkeypatch, tmp_path):
         def get(self, player_id):
             return next(player for player in self.players if player.id == player_id)
 
+    class EmptyHistoryQuery:
+        def filter_by(self, **_kwargs):
+            return self
+
+        def order_by(self, *_args):
+            return self
+
+        def first(self):
+            return None
+
     participant_model = SimpleNamespace(id=IdField(), query=ParticipantQuery(participants))
     monkeypatch.setattr(app_module, "Participant", participant_model)
-    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, remove=lambda: None))
+    monkeypatch.setattr(app_module, "MatchRound", SimpleNamespace(id=SimpleNamespace(desc=lambda: None), query=EmptyHistoryQuery()))
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, rollback=lambda: None, delete=lambda obj: None, remove=lambda: None))
     return app_module
 
 
@@ -507,7 +518,7 @@ def configure_confirmation_state(monkeypatch, app_module, initial_state):
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
     monkeypatch.setattr(app_module, "save_match_state_full", save_state)
-    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, remove=lambda: None))
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, rollback=lambda: None, remove=lambda: None))
     return participants, state
 
 

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -126,7 +126,7 @@ def load_db_test_app(monkeypatch, tmp_path):
 
     participant_model = SimpleNamespace(id=IdField(), query=ParticipantQuery(participants))
     monkeypatch.setattr(app_module, "Participant", participant_model)
-    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(commit=lambda: None, remove=lambda: None))
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, remove=lambda: None))
     return app_module
 
 
@@ -507,7 +507,7 @@ def configure_confirmation_state(monkeypatch, app_module, initial_state):
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(app_module, "load_match_state", lambda: state.copy())
     monkeypatch.setattr(app_module, "save_match_state_full", save_state)
-    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(commit=lambda: None, remove=lambda: None))
+    monkeypatch.setattr(app_module.db, "session", SimpleNamespace(add=lambda obj: None, flush=lambda: None, commit=lambda: None, remove=lambda: None))
     return participants, state
 
 

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -124,3 +124,118 @@ def test_reset_db_deletes_history_before_participants_without_constraint_error(m
         assert app_module.MatchHistory.query.count() == 0
         assert app_module.MatchRound.query.count() == 0
         assert app_module.Participant.query.count() == 0
+
+
+def test_ensure_database_tables_adds_missing_history_tables_for_existing_db(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    matches = [[1, 2, 3, 4]]
+    write_draft(tmp_path, matches, [])
+
+    with app_module.app.app_context():
+        add_participants(app_module, 4)
+        app_module.BenchHistory.__table__.drop(app_module.db.engine)
+        app_module.MatchHistory.__table__.drop(app_module.db.engine)
+        app_module.MatchRound.__table__.drop(app_module.db.engine)
+
+        app_module.ensure_database_tables()
+        response = app_module.app.test_client().post("/match/confirm")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 0
+
+
+def test_revert_match_to_draft_deletes_corresponding_history(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    matches = [[1, 2, 3, 4]]
+    bench = [5]
+    write_draft(tmp_path, matches, bench)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        client = app_module.app.test_client()
+        client.post("/match/confirm")
+
+        response = client.post("/match/revert_to_draft", data={"mode": "admin"})
+
+        assert response.status_code == 302
+        assert app_module.BenchHistory.query.count() == 0
+        assert app_module.MatchHistory.query.count() == 0
+        assert app_module.MatchRound.query.count() == 0
+
+
+def test_revert_then_reconfirm_does_not_keep_cancelled_duplicate_history(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    original_matches = [[1, 2, 3, 4]]
+    edited_matches = [[4, 3, 2, 1]]
+    write_draft(tmp_path, original_matches, [5])
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        client = app_module.app.test_client()
+        client.post("/match/confirm")
+        client.post("/match/revert_to_draft", data={"mode": "admin"})
+        write_draft(tmp_path, edited_matches, [5])
+        response = client.post("/match/confirm")
+
+        assert response.status_code == 302
+        rounds = app_module.MatchRound.query.all()
+        assert len(rounds) == 1
+        assert rounds[0].round_number == 1
+        histories = app_module.MatchHistory.query.all()
+        assert len(histories) == 1
+        assert [
+            histories[0].team1_player1_id,
+            histories[0].team1_player2_id,
+            histories[0].team2_player1_id,
+            histories[0].team2_player2_id,
+        ] == edited_matches[0]
+
+
+def test_confirm_rolls_back_db_when_saving_match_state_fails(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, [[1, 2, 3, 4]], [])
+
+    def fail_save(*args, **kwargs):
+        raise OSError("cannot save match state")
+
+    monkeypatch.setattr(app_module, "save_match_state_full", fail_save)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 4)
+        client = app_module.app.test_client()
+        try:
+            client.post("/match/confirm")
+            assert False, "expected save_match_state_full failure"
+        except OSError:
+            pass
+
+        assert app_module.MatchRound.query.count() == 0
+        assert app_module.MatchHistory.query.count() == 0
+        assert [p.games_played for p in app_module.Participant.query.order_by(app_module.Participant.id).all()] == [0, 0, 0, 0]
+        assert (tmp_path / "draft_state.json").exists()
+
+
+def test_confirm_rolls_back_db_when_clearing_draft_fails(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, [[1, 2, 3, 4]], [])
+
+    def fail_clear():
+        raise OSError("cannot clear draft")
+
+    monkeypatch.setattr(app_module, "clear_draft_state", fail_clear)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 4)
+        client = app_module.app.test_client()
+        try:
+            client.post("/match/confirm")
+            assert False, "expected clear_draft_state failure"
+        except OSError:
+            pass
+
+        assert app_module.MatchRound.query.count() == 0
+        assert app_module.MatchHistory.query.count() == 0
+        assert [p.games_played for p in app_module.Participant.query.order_by(app_module.Participant.id).all()] == [0, 0, 0, 0]
+        assert (tmp_path / "draft_state.json").exists()

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1,0 +1,126 @@
+import importlib
+import json
+import os
+import sys
+
+
+def load_history_test_app(monkeypatch, tmp_path):
+    config = {"level_map": {}, "gender_weight": {}}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    os.makedirs(app_module.app.instance_path, exist_ok=True)
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.app_context():
+        app_module.db.drop_all()
+        app_module.db.create_all()
+    return app_module
+
+
+def add_participants(app_module, count):
+    participants = []
+    for player_id in range(1, count + 1):
+        participant = app_module.Participant(
+            name=f"player-{player_id}",
+            gender="male",
+            level="beginner",
+            weight=1.0,
+            card=f"C{player_id}",
+        )
+        participants.append(participant)
+        app_module.db.session.add(participant)
+    app_module.db.session.commit()
+    return participants
+
+
+def write_draft(tmp_path, matches, bench, court_count=None):
+    draft = {"draft": True, "matches": matches, "bench": bench}
+    if court_count is not None:
+        draft["court_count"] = court_count
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
+
+
+def test_confirm_match_persists_round_matches_bench_and_preserves_state_flow(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    matches = [[1, 2, 3, 4], [5, 6, 7, 8]]
+    bench = [9]
+    write_draft(tmp_path, matches, bench, court_count=2)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 9)
+        response = app_module.app.test_client().post("/match/confirm", data={"mode": "admin"})
+
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/match/result?mode=admin")
+
+        rounds = app_module.MatchRound.query.all()
+        assert len(rounds) == 1
+        assert rounds[0].round_number == 1
+
+        histories = app_module.MatchHistory.query.order_by(app_module.MatchHistory.court_number).all()
+        assert len(histories) == len(matches)
+        assert [
+            [
+                history.team1_player1_id,
+                history.team1_player2_id,
+                history.team2_player1_id,
+                history.team2_player2_id,
+            ]
+            for history in histories
+        ] == matches
+        assert all(history.team1_score is None for history in histories)
+        assert all(history.team2_score is None for history in histories)
+        assert all(history.winner_team is None for history in histories)
+
+        bench_histories = app_module.BenchHistory.query.all()
+        assert len(bench_histories) == len(bench)
+        assert [history.participant_id for history in bench_histories] == bench
+
+        state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+        assert state["match_active"] is True
+        assert state["match_count"] == 1
+        assert state["matches"] == matches
+        assert state["bench"] == bench
+        assert state["court_count"] == 2
+        assert not (tmp_path / "draft_state.json").exists()
+
+        with app_module.app.test_client().session_transaction() as session:
+            assert "draft_matches" not in session
+            assert "draft_bench" not in session
+            assert "court_count" not in session
+            assert "last_confirmed_matches" not in session
+            assert "last_confirmed_bench" not in session
+
+
+def test_reset_match_keeps_history_records(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, [[1, 2, 3, 4]], [5])
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        client = app_module.app.test_client()
+        client.post("/match/confirm")
+        response = client.post("/reset_match")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 1
+
+
+def test_reset_db_deletes_history_before_participants_without_constraint_error(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, [[1, 2, 3, 4]], [5])
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        client = app_module.app.test_client()
+        client.post("/match/confirm")
+        response = client.post("/admin/reset_db")
+
+        assert response.status_code == 302
+        assert app_module.BenchHistory.query.count() == 0
+        assert app_module.MatchHistory.query.count() == 0
+        assert app_module.MatchRound.query.count() == 0
+        assert app_module.Participant.query.count() == 0


### PR DESCRIPTION
### Motivation
- 確定済みの組み合わせを将来参照できるように DB に履歴を蓄積するため、既存の `draft_state.json` / `match_state.json` 方針は維持しつつ確定時に履歴を保存する機能を追加します。 
- 将来のスコア入力や履歴ベースのマッチングに備えて、コート単位の履歴とベンチ履歴を記録可能にします。 

### Description
- `models.py` に `MatchRound`, `MatchHistory`, `BenchHistory` の 3 つのモデルを追加し、`MatchHistory` のスコア・勝者カラムは将来用途のため `nullable` としました。 
- `/match/confirm` 処理を拡張して、確定時に `MatchRound` を作成し、各コート分の `MatchHistory` とベンチ分の `BenchHistory` を同一トランザクションで `db.session` に追加し、同時に該当参加者の `games_played` を更新してコミットするようにしました。 
- `reset_match` の既存動作は変更せず履歴は削除しないままにし、`/admin/reset_db` はテーブルが存在しないケースに備えて `db.create_all()` を呼び出した上で履歴テーブルを先に削除し、その後参加者を削除する依存順での削除に変更しました。 
- 履歴に関する自動テストとして `tests/test_match_history.py` を追加し、既存の確認系テストに合わせてテスト用の DB セッションスタブに `add`/`flush` を許すよう `tests/test_match_draft.py` のテストスタブを調整しました。 

### Testing
- 新規テスト `tests/test_match_history.py` を含めて `pytest` を実行し、全テストが通過しました（`72 passed`）。 
- 確定処理の振る舞いは `tests/test_match_history.py` のケースで、`MatchRound`／`MatchHistory`／`BenchHistory` の生成と `match_state.json` / `draft_state.json` フローが期待通りであることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf49c6b483338ff46ab76dc8bf11)