### PR TITLE
Add admin match history page

### DIFF
--- a/app.py
+++ b/app.py
@@ -708,7 +708,18 @@ def reset_db():
     return redirect(url_for('admin_settings'))
 
 
-def get_participant_name_map(rounds):
+def format_participant_label(participant):
+    if participant is None:
+        return "[]不明な参加者"
+
+    card = participant.card or ""
+    if card in ("JOKER_RED", "JOKER_BLACK"):
+        card = "JK"
+
+    return f"[{card}]{participant.name}"
+
+
+def get_participant_label_map(rounds):
     participant_ids = set()
     for match_round in rounds:
         for match in match_round.matches:
@@ -725,7 +736,7 @@ def get_participant_name_map(rounds):
         return {}
 
     participants = Participant.query.filter(Participant.id.in_(participant_ids)).all()
-    return {participant.id: participant.name for participant in participants}
+    return {participant.id: format_participant_label(participant) for participant in participants}
 
 
 @app.route('/admin/match_history')
@@ -739,12 +750,12 @@ def admin_match_history():
         .order_by(MatchRound.created_at.desc(), MatchRound.id.desc())
         .all()
     )
-    participant_names = get_participant_name_map(rounds)
+    participant_labels = get_participant_label_map(rounds)
 
     return render_template(
         'match_history.html',
         rounds=rounds,
-        participant_names=participant_names,
+        participant_labels=participant_labels,
     )
 
 # 管理者向けトップページ

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from models import db, Participant, MatchRound, MatchHistory, BenchHistory
 # from flask_sqlalchemy import SQLAlchemy
 from flask import flash
 from flask import Response
+from sqlalchemy.orm import selectinload
 from flask import send_from_directory
 from flask import send_file
 import qrcode
@@ -731,6 +732,10 @@ def get_participant_name_map(rounds):
 def admin_match_history():
     rounds = (
         MatchRound.query
+        .options(
+            selectinload(MatchRound.matches),
+            selectinload(MatchRound.bench_players),
+        )
         .order_by(MatchRound.created_at.desc(), MatchRound.id.desc())
         .all()
     )

--- a/app.py
+++ b/app.py
@@ -706,6 +706,42 @@ def reset_db():
     flash('参加者データと試合情報をすべて削除しました')
     return redirect(url_for('admin_settings'))
 
+
+def get_participant_name_map(rounds):
+    participant_ids = set()
+    for match_round in rounds:
+        for match in match_round.matches:
+            participant_ids.update([
+                match.team1_player1_id,
+                match.team1_player2_id,
+                match.team2_player1_id,
+                match.team2_player2_id,
+            ])
+        for bench_history in match_round.bench_players:
+            participant_ids.add(bench_history.participant_id)
+
+    if not participant_ids:
+        return {}
+
+    participants = Participant.query.filter(Participant.id.in_(participant_ids)).all()
+    return {participant.id: participant.name for participant in participants}
+
+
+@app.route('/admin/match_history')
+def admin_match_history():
+    rounds = (
+        MatchRound.query
+        .order_by(MatchRound.created_at.desc(), MatchRound.id.desc())
+        .all()
+    )
+    participant_names = get_participant_name_map(rounds)
+
+    return render_template(
+        'match_history.html',
+        rounds=rounds,
+        participant_names=participant_names,
+    )
+
 # 管理者向けトップページ
 @app.route('/admin')
 def admin_index():

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,6 +75,7 @@
     <button onclick="location.reload()">🔄 表示を更新</button>
     <p>
         {% if mode == 'admin' %}
+            <a href="{{ url_for('admin_match_history') }}">📋 試合履歴</a><br>
             {% if has_confirmed %}
                 <a href="{{ url_for('match_result', mode=mode) }}">▶ 確定済み組み合わせを表示</a>
             {% endif %}

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>試合履歴</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            line-height: 1.6;
+            margin: 16px;
+        }
+
+        .history-round {
+            border: 1px solid #ccc;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 16px;
+        }
+
+        .round-heading {
+            margin: 0 0 12px;
+            font-size: 20px;
+        }
+
+        .court-card {
+            background: #f8f8f8;
+            border-radius: 6px;
+            padding: 10px;
+            margin: 10px 0;
+        }
+
+        .court-title {
+            font-weight: bold;
+            margin-bottom: 4px;
+        }
+
+        .score-status {
+            color: #555;
+            font-size: 14px;
+            margin-top: 4px;
+        }
+
+        .empty-message {
+            color: #666;
+            font-size: 18px;
+        }
+
+        @media (max-width: 600px) {
+            body {
+                margin: 10px;
+            }
+
+            .history-round {
+                padding: 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <h1>試合履歴</h1>
+    <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a></p>
+
+    {% if rounds %}
+        {% for round in rounds %}
+            <section class="history-round" data-round-id="{{ round.id }}">
+                <h2 class="round-heading">
+                    第{{ round.round_number }}試合
+                    <time datetime="{{ round.created_at.isoformat() }}">
+                        {{ round.created_at.strftime('%Y-%m-%d %H:%M') }}
+                    </time>
+                </h2>
+
+                {% for match in round.matches|sort(attribute='court_number') %}
+                    <div class="court-card" data-match-history-id="{{ match.id }}">
+                        <div class="court-title">{{ match.court_number }}コート</div>
+                        <div>
+                            {{ participant_names.get(match.team1_player1_id, '不明な参加者') }}・{{ participant_names.get(match.team1_player2_id, '不明な参加者') }}
+                            vs
+                            {{ participant_names.get(match.team2_player1_id, '不明な参加者') }}・{{ participant_names.get(match.team2_player2_id, '不明な参加者') }}
+                        </div>
+                        <div class="score-status">
+                            {% if match.team1_score is none or match.team2_score is none or match.winner_team is none %}
+                                結果未入力
+                            {% else %}
+                                {{ match.team1_score }} - {{ match.team2_score }} / 勝者: team{{ match.winner_team }}
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endfor %}
+
+                <div class="bench-section">
+                    <strong>ベンチ</strong>
+                    {% if round.bench_players %}
+                        <div>
+                            {% for bench in round.bench_players|sort(attribute='id') %}
+                                {{ participant_names.get(bench.participant_id, '不明な参加者') }}{% if not loop.last %}, {% endif %}
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <div>ベンチ参加者はいません。</div>
+                    {% endif %}
+                </div>
+            </section>
+        {% endfor %}
+    {% else %}
+        <p class="empty-message">試合履歴はまだありません。</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -74,9 +74,9 @@
                     <div class="court-card" data-match-history-id="{{ match.id }}">
                         <div class="court-title">{{ match.court_number }}コート</div>
                         <div>
-                            {{ participant_names.get(match.team1_player1_id, '不明な参加者') }}・{{ participant_names.get(match.team1_player2_id, '不明な参加者') }}
+                            {{ participant_labels.get(match.team1_player1_id, '[]不明な参加者') }}・{{ participant_labels.get(match.team1_player2_id, '[]不明な参加者') }}
                             vs
-                            {{ participant_names.get(match.team2_player1_id, '不明な参加者') }}・{{ participant_names.get(match.team2_player2_id, '不明な参加者') }}
+                            {{ participant_labels.get(match.team2_player1_id, '[]不明な参加者') }}・{{ participant_labels.get(match.team2_player2_id, '[]不明な参加者') }}
                         </div>
                         <div class="score-status">
                             {% if match.team1_score is none or match.team2_score is none or match.winner_team is none %}
@@ -93,7 +93,7 @@
                     {% if round.bench_players %}
                         <div>
                             {% for bench in round.bench_players|sort(attribute='id') %}
-                                {{ participant_names.get(bench.participant_id, '不明な参加者') }}{% if not loop.last %}, {% endif %}
+                                {{ participant_labels.get(bench.participant_id, '[]不明な参加者') }}{% if not loop.last %}, {% endif %}
                             {% endfor %}
                         </div>
                     {% else %}

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -239,3 +239,91 @@ def test_confirm_rolls_back_db_when_clearing_draft_fails(monkeypatch, tmp_path):
         assert app_module.MatchHistory.query.count() == 0
         assert [p.games_played for p in app_module.Participant.query.order_by(app_module.Participant.id).all()] == [0, 0, 0, 0]
         assert (tmp_path / "draft_state.json").exists()
+
+
+def test_admin_match_history_page_displays_round_matches_bench_and_scores(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 9)
+        from datetime import datetime, timezone
+        round_record = app_module.MatchRound(
+            round_number=5,
+            created_at=datetime(2026, 6, 27, 19, 30, tzinfo=timezone.utc),
+        )
+        app_module.db.session.add(round_record)
+        app_module.db.session.flush()
+        app_module.db.session.add(app_module.MatchHistory(
+            round_id=round_record.id,
+            court_number=1,
+            team1_player1_id=1,
+            team1_player2_id=2,
+            team2_player1_id=3,
+            team2_player2_id=4,
+        ))
+        app_module.db.session.add(app_module.MatchHistory(
+            round_id=round_record.id,
+            court_number=2,
+            team1_player1_id=5,
+            team1_player2_id=6,
+            team2_player1_id=7,
+            team2_player2_id=8,
+            team1_score=21,
+            team2_score=18,
+            winner_team=1,
+        ))
+        app_module.db.session.add(app_module.BenchHistory(round_id=round_record.id, participant_id=9))
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().get("/admin/match_history")
+
+        html = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "第5試合" in html
+        assert "2026-06-27 19:30" in html
+        assert "1コート" in html
+        assert "player-1・player-2" in html
+        assert "player-3・player-4" in html
+        assert "2コート" in html
+        assert "player-5・player-6" in html
+        assert "player-7・player-8" in html
+        assert "player-9" in html
+        assert "結果未入力" in html
+        assert "21 - 18 / 勝者: team1" in html
+
+
+def test_admin_match_history_page_orders_newest_round_first(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        from datetime import datetime, timezone
+        app_module.db.session.add(app_module.MatchRound(round_number=1, created_at=datetime(2026, 6, 27, 18, 0, tzinfo=timezone.utc)))
+        app_module.db.session.add(app_module.MatchRound(round_number=2, created_at=datetime(2026, 6, 27, 19, 0, tzinfo=timezone.utc)))
+        app_module.db.session.commit()
+
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert html.index("第2試合") < html.index("第1試合")
+
+
+def test_admin_match_history_page_displays_empty_message(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().get("/admin/match_history")
+
+        assert response.status_code == 200
+        assert "試合履歴はまだありません" in response.get_data(as_text=True)
+
+
+def test_admin_index_links_to_match_history_but_viewer_index_does_not(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        admin_html = app_module.app.test_client().get("/admin").get_data(as_text=True)
+        viewer_html = app_module.app.test_client().get("/viewer").get_data(as_text=True)
+
+        assert "/admin/match_history" in admin_html
+        assert "試合履歴" in admin_html
+        assert "/admin/match_history" not in viewer_html
+        assert "試合履歴" not in viewer_html

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -305,6 +305,50 @@ def test_admin_match_history_page_orders_newest_round_first(monkeypatch, tmp_pat
 
         assert html.index("第2試合") < html.index("第1試合")
 
+def test_admin_match_history_eager_loads_round_relationships(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 15)
+        for round_number in range(1, 4):
+            round_record = app_module.MatchRound(round_number=round_number)
+            app_module.db.session.add(round_record)
+            app_module.db.session.flush()
+            player_offset = (round_number - 1) * 4
+            app_module.db.session.add(app_module.MatchHistory(
+                round_id=round_record.id,
+                court_number=1,
+                team1_player1_id=player_offset + 1,
+                team1_player2_id=player_offset + 2,
+                team2_player1_id=player_offset + 3,
+                team2_player2_id=player_offset + 4,
+            ))
+            app_module.db.session.add(app_module.BenchHistory(
+                round_id=round_record.id,
+                participant_id=13 + (round_number - 1),
+            ))
+        app_module.db.session.commit()
+
+        from sqlalchemy import event
+
+        relationship_selects = {"match_histories": 0, "bench_histories": 0}
+
+        def count_relationship_selects(conn, cursor, statement, parameters, context, executemany):
+            normalized = statement.lower()
+            if normalized.lstrip().startswith("select"):
+                for table_name in relationship_selects:
+                    if f"from {table_name}" in normalized:
+                        relationship_selects[table_name] += 1
+
+        event.listen(app_module.db.engine, "before_cursor_execute", count_relationship_selects)
+        try:
+            response = app_module.app.test_client().get("/admin/match_history")
+        finally:
+            event.remove(app_module.db.engine, "before_cursor_execute", count_relationship_selects)
+
+        assert response.status_code == 200
+        assert relationship_selects == {"match_histories": 1, "bench_histories": 1}
+
 
 def test_admin_match_history_page_displays_empty_message(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -282,14 +282,51 @@ def test_admin_match_history_page_displays_round_matches_bench_and_scores(monkey
         assert "第5試合" in html
         assert "2026-06-27 19:30" in html
         assert "1コート" in html
-        assert "player-1・player-2" in html
-        assert "player-3・player-4" in html
+        assert "[C1]player-1・[C2]player-2" in html
+        assert "[C3]player-3・[C4]player-4" in html
         assert "2コート" in html
-        assert "player-5・player-6" in html
-        assert "player-7・player-8" in html
-        assert "player-9" in html
+        assert "[C5]player-5・[C6]player-6" in html
+        assert "[C7]player-7・[C8]player-8" in html
+        assert "[C9]player-9" in html
         assert "結果未入力" in html
         assert "21 - 18 / 勝者: team1" in html
+
+
+def test_admin_match_history_page_formats_special_and_missing_participant_cards(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        participants = [
+            app_module.Participant(name="heart", gender="female", level="beginner", weight=1.0, card="♥A"),
+            app_module.Participant(name="red-joker", gender="male", level="beginner", weight=1.0, card="JOKER_RED"),
+            app_module.Participant(name="black-joker", gender="male", level="beginner", weight=1.0, card="JOKER_BLACK"),
+            app_module.Participant(name="no-card", gender="female", level="beginner", weight=1.0, card=""),
+        ]
+        app_module.db.session.add_all(participants)
+        app_module.db.session.flush()
+        round_record = app_module.MatchRound(round_number=1)
+        app_module.db.session.add(round_record)
+        app_module.db.session.flush()
+        app_module.db.session.add(app_module.MatchHistory(
+            round_id=round_record.id,
+            court_number=1,
+            team1_player1_id=participants[0].id,
+            team1_player2_id=participants[1].id,
+            team2_player1_id=participants[2].id,
+            team2_player2_id=9999,
+        ))
+        app_module.db.session.add(app_module.BenchHistory(round_id=round_record.id, participant_id=participants[3].id))
+        app_module.db.session.add(app_module.BenchHistory(round_id=round_record.id, participant_id=9998))
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().get("/admin/match_history")
+
+        html = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "[♥A]heart・[JK]red-joker" in html
+        assert "[JK]black-joker・[]不明な参加者" in html
+        assert "[]no-card" in html
+        assert "[]不明な参加者" in html
 
 
 def test_admin_match_history_page_orders_newest_round_first(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Provide an administrator-facing page to inspect persisted `MatchRound`, `MatchHistory`, and `BenchHistory` records saved by the confirm flow so admins can review past rounds.
- Show history newest-first so recent rounds are immediately visible.
- Structure the page and per-`MatchHistory` output to make future score editing routes (e.g. `/admin/match_history/<match_history_id>/score`) straightforward to add.

### Description
- Added an admin route `@app.route('/admin/match_history')` and helper `get_participant_name_map` in `app.py` that loads rounds ordered by `MatchRound.created_at.desc(), MatchRound.id.desc()` and resolves participant names from participant IDs.
- Introduced a new template `templates/match_history.html` to render rounds, per-court `MatchHistory` entries, bench lists from `BenchHistory`, created/confirmed timestamps, and score/winner display (shows `結果未入力` when scores/winner are missing).
- Added an admin-only link to the history page from the admin index in `templates/index.html` while leaving viewer pages unchanged.
- Added tests in `tests/test_match_history.py` that verify rendering of rounds, datetime, court pairings, bench participants, score display, newest-first ordering, empty-state messaging, and admin/viewer navigation visibility.

### Testing
- Ran `pytest tests/test_match_history.py -q` and the new tests passed successfully. 
- Ran the full test suite with `pytest -q` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7f4792dc833386f387d5efbc5768)