### PR TITLE
Admin: score input mode settings and editable match history results

### DIFF
--- a/app.py
+++ b/app.py
@@ -806,9 +806,26 @@ def parse_optional_int(value):
         return None
 
 
+def parse_optional_score(value, max_score):
+    if value is None or str(value).strip() == "":
+        return True, None
+    try:
+        score = int(value)
+    except (TypeError, ValueError):
+        return False, None
+    if score < 0 or score > max_score:
+        return False, None
+    return True, score
+
+
 def parse_winner_team(value):
     winner = parse_optional_int(value)
     return winner if winner in (1, 2) else None
+
+
+def get_max_match_score(config):
+    scoring_system = config["scoring_system"]
+    return scoring_system["points_per_game"] * scoring_system["games_per_match"]
 
 
 @app.route('/admin/match_history/<int:match_history_id>/score', methods=['POST'])
@@ -818,15 +835,21 @@ def update_match_history_score(match_history_id):
         flash('指定された試合履歴が見つかりません')
         return redirect(url_for('admin_match_history'))
 
-    score_input_mode = load_config()["score_input_mode"]
+    config = load_config()
+    score_input_mode = config["score_input_mode"]
     winner_team = parse_winner_team(request.form.get('winner_team'))
 
     if score_input_mode == "score":
-        team1_score = parse_optional_int(request.form.get('team1_score'))
-        team2_score = parse_optional_int(request.form.get('team2_score'))
+        max_score = get_max_match_score(config)
+        team1_score_valid, team1_score = parse_optional_score(request.form.get('team1_score'), max_score)
+        team2_score_valid, team2_score = parse_optional_score(request.form.get('team2_score'), max_score)
+        if not team1_score_valid or not team2_score_valid:
+            flash(f'スコアは0から{max_score}までの数値で入力してください')
+            return redirect(url_for('admin_match_history'))
+
         match_history.team1_score = team1_score
         match_history.team2_score = team2_score
-        if winner_team is None and team1_score is not None and team2_score is not None:
+        if 'winner_team' not in request.form and team1_score is not None and team2_score is not None:
             if team1_score > team2_score:
                 winner_team = 1
             elif team2_score > team1_score:

--- a/app.py
+++ b/app.py
@@ -3,12 +3,14 @@ import os
 import json
 import io
 import logging
+import re
 from io import TextIOWrapper
 from flask import Flask, render_template, request, redirect, url_for, abort
 from models import db, Participant, MatchRound, MatchHistory, BenchHistory
 # from flask_sqlalchemy import SQLAlchemy
 from flask import flash
 from flask import Response
+from sqlalchemy import inspect, text
 from sqlalchemy.orm import selectinload
 from flask import send_from_directory
 from flask import send_file
@@ -62,6 +64,18 @@ def ensure_database_tables():
     os.makedirs(app.instance_path, exist_ok=True)
     with app.app_context():
         db.create_all()
+        ensure_match_history_score_text_column()
+
+
+def ensure_match_history_score_text_column():
+    """Add score_text to existing SQLite match history tables when missing."""
+    inspector = inspect(db.engine)
+    if not inspector.has_table(MatchHistory.__tablename__):
+        return
+    column_names = {column["name"] for column in inspector.get_columns(MatchHistory.__tablename__)}
+    if "score_text" not in column_names:
+        db.session.execute(text("ALTER TABLE match_histories ADD COLUMN score_text TEXT"))
+        db.session.commit()
 
 
 ensure_database_tables()
@@ -76,7 +90,7 @@ ALL_CARDS = [
     
 VALID_SCORE_INPUT_MODES = {"winner_only", "score"}
 DEFAULT_SCORE_INPUT_MODE = "winner_only"
-DEFAULT_SCORING_SYSTEM = {"points_per_game": 21, "games_per_match": 1}
+DEFAULT_SCORING_SYSTEM = {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": False, "max_points": 21}
 
 
 def parse_positive_int(value, default):
@@ -93,18 +107,33 @@ def normalize_score_input_mode(value):
     return DEFAULT_SCORE_INPUT_MODE
 
 
+def parse_bool(value, default=False):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).lower() in {"1", "true", "on", "yes"}
+
+
 def normalize_scoring_system(value):
     if not isinstance(value, dict):
         value = {}
+    points_per_game = parse_positive_int(
+        value.get("points_per_game"),
+        DEFAULT_SCORING_SYSTEM["points_per_game"],
+    )
+    games_per_match = parse_positive_int(
+        value.get("games_per_match"),
+        DEFAULT_SCORING_SYSTEM["games_per_match"],
+    )
+    max_points = parse_positive_int(value.get("max_points"), points_per_game)
+    if max_points < points_per_game:
+        max_points = points_per_game
     return {
-        "points_per_game": parse_positive_int(
-            value.get("points_per_game"),
-            DEFAULT_SCORING_SYSTEM["points_per_game"],
-        ),
-        "games_per_match": parse_positive_int(
-            value.get("games_per_match"),
-            DEFAULT_SCORING_SYSTEM["games_per_match"],
-        ),
+        "points_per_game": points_per_game,
+        "games_per_match": games_per_match,
+        "deuce_enabled": parse_bool(value.get("deuce_enabled"), DEFAULT_SCORING_SYSTEM["deuce_enabled"]),
+        "max_points": max_points,
     }
 
 
@@ -740,6 +769,8 @@ def admin_settings():
             "scoring_system": normalize_scoring_system({
                 "points_per_game": request.form.get('points_per_game'),
                 "games_per_match": request.form.get('games_per_match'),
+                "deuce_enabled": request.form.get('deuce_enabled'),
+                "max_points": request.form.get('max_points'),
             }),
         }
         with open('config.json', 'w', encoding='utf-8') as f:
@@ -806,26 +837,71 @@ def parse_optional_int(value):
         return None
 
 
-def parse_optional_score(value, max_score):
-    if value is None or str(value).strip() == "":
-        return True, None
-    try:
-        score = int(value)
-    except (TypeError, ValueError):
-        return False, None
-    if score < 0 or score > max_score:
-        return False, None
-    return True, score
-
-
 def parse_winner_team(value):
     winner = parse_optional_int(value)
     return winner if winner in (1, 2) else None
 
 
-def get_max_match_score(config):
-    scoring_system = config["scoring_system"]
-    return scoring_system["points_per_game"] * scoring_system["games_per_match"]
+GAME_SCORE_RE = re.compile(r"^(\d+)\s*-\s*(\d+)$")
+
+
+def decide_game_winner(left_score, right_score, scoring_system):
+    points_per_game = scoring_system["points_per_game"]
+    max_points = scoring_system["max_points"]
+    if left_score > max_points or right_score > max_points:
+        return None
+    if left_score == right_score:
+        return None
+
+    high_score = max(left_score, right_score)
+    low_score = min(left_score, right_score)
+    if not scoring_system["deuce_enabled"]:
+        if high_score != points_per_game:
+            return None
+    elif high_score < points_per_game:
+        return None
+    elif high_score != max_points and high_score - low_score < 2:
+        return None
+
+    return 1 if left_score > right_score else 2
+
+
+def parse_score_text(score_text, scoring_system):
+    normalized_text = (score_text or "").strip()
+    if normalized_text == "":
+        return True, None, None, None, None
+
+    team1_games = 0
+    team2_games = 0
+    effective_lines = []
+    for raw_line in score_text.splitlines():
+        line = raw_line.strip()
+        if line == "":
+            continue
+        match = GAME_SCORE_RE.match(line)
+        if match is None:
+            return False, None, None, None, f'不正なスコア行があります: {line}'
+        left_score, right_score = int(match.group(1)), int(match.group(2))
+        winner = decide_game_winner(left_score, right_score, scoring_system)
+        if winner is None:
+            return False, None, None, None, f'勝敗を判定できないスコア行があります: {line}'
+        if winner == 1:
+            team1_games += 1
+        else:
+            team2_games += 1
+        effective_lines.append(f"{left_score}-{right_score}")
+
+    if not effective_lines:
+        return True, None, None, None, None
+    if len(effective_lines) > scoring_system["games_per_match"]:
+        return False, None, None, None, f'{scoring_system["games_per_match"]}ゲーム以内で入力してください'
+
+    winner_team = None
+    if team1_games > team2_games:
+        winner_team = 1
+    elif team2_games > team1_games:
+        winner_team = 2
+    return True, "\n".join(effective_lines), team1_games, team2_games, winner_team
 
 
 @app.route('/admin/match_history/<int:match_history_id>/score', methods=['POST'])
@@ -837,31 +913,26 @@ def update_match_history_score(match_history_id):
 
     config = load_config()
     score_input_mode = config["score_input_mode"]
-    winner_team = parse_winner_team(request.form.get('winner_team'))
 
     if score_input_mode == "score":
-        max_score = get_max_match_score(config)
-        team1_score_valid, team1_score = parse_optional_score(request.form.get('team1_score'), max_score)
-        team2_score_valid, team2_score = parse_optional_score(request.form.get('team2_score'), max_score)
-        if not team1_score_valid or not team2_score_valid:
-            flash(f'スコアは0から{max_score}までの数値で入力してください')
+        valid, score_text, team1_score, team2_score, winner_team_or_error = parse_score_text(
+            request.form.get('score_text'),
+            config["scoring_system"],
+        )
+        if not valid:
+            flash(winner_team_or_error or 'ゲーム別スコアを正しく入力してください')
             return redirect(url_for('admin_match_history'))
-
+        winner_team = winner_team_or_error
+        match_history.score_text = score_text
         match_history.team1_score = team1_score
         match_history.team2_score = team2_score
-        if 'winner_team' not in request.form and team1_score is not None and team2_score is not None:
-            if team1_score > team2_score:
-                winner_team = 1
-            elif team2_score > team1_score:
-                winner_team = 2
         match_history.winner_team = winner_team
     else:
-        match_history.winner_team = winner_team
+        match_history.winner_team = parse_winner_team(request.form.get('winner_team'))
 
     db.session.commit()
     flash('試合結果を保存しました')
     return redirect(url_for('admin_match_history'))
-
 
 @app.route('/admin/match_history')
 def admin_match_history():

--- a/app.py
+++ b/app.py
@@ -676,11 +676,30 @@ def update_court_count():
 
     return redirect(url_for('edit_matches', mode=mode))
 
+def get_latest_match_histories_by_court(match_count):
+    """Return MatchHistory rows for the latest persisted round by court number."""
+    match_round = (
+        MatchRound.query
+        .options(selectinload(MatchRound.matches))
+        .filter_by(round_number=match_count)
+        .order_by(MatchRound.id.desc())
+        .first()
+    )
+    if match_round is None:
+        return {}
+    return {match.court_number: match for match in match_round.matches}
+
+
 def render_match_result_page(match_ids, bench_ids, match_count, mode, *, is_draft, has_draft, has_confirmed):
     participants = {p.id: p for p in Participant.query.all()}
 
     matches = [[participants[pid] for pid in group] for group in match_ids]
     bench = [participants[pid] for pid in bench_ids] if bench_ids else []
+    config = load_config()
+    scoring_system = config["scoring_system"]
+    match_histories_by_court = {}
+    if mode == 'admin' and not is_draft and has_confirmed:
+        match_histories_by_court = get_latest_match_histories_by_court(match_count)
 
     return render_template(
         'match_result.html',
@@ -692,6 +711,14 @@ def render_match_result_page(match_ids, bench_ids, match_count, mode, *, is_draf
         is_draft=is_draft,
         has_draft=has_draft,
         has_confirmed=has_confirmed,
+        match_histories_by_court=match_histories_by_court,
+        score_input_mode=config["score_input_mode"],
+        scoring_system=scoring_system,
+        score_options=list(range(scoring_system["max_points"] + 1)),
+        score_rows_by_match_id={
+            match.id: parse_score_text_rows(match.score_text, scoring_system["games_per_match"])
+            for match in match_histories_by_court.values()
+        },
     )
 
 
@@ -958,6 +985,35 @@ def parse_score_text(score_text, scoring_system):
     return True, "\n".join(effective_lines), team1_games, team2_games, winner_team
 
 
+def apply_match_history_score_update(match_history, form):
+    """Apply score form values to a MatchHistory row without committing."""
+    config = load_config()
+    score_input_mode = config["score_input_mode"]
+
+    if score_input_mode == "score":
+        dropdown_valid, posted_score_text, dropdown_error = build_score_text_from_dropdowns(
+            form,
+            config["scoring_system"]["games_per_match"],
+        )
+        if not dropdown_valid:
+            return False, dropdown_error or 'ゲーム別スコアを正しく入力してください'
+        valid, score_text, team1_score, team2_score, winner_team_or_error = parse_score_text(
+            posted_score_text,
+            config["scoring_system"],
+        )
+        if not valid:
+            return False, winner_team_or_error or 'ゲーム別スコアを正しく入力してください'
+        winner_team = winner_team_or_error
+        match_history.score_text = score_text
+        match_history.team1_score = team1_score
+        match_history.team2_score = team2_score
+        match_history.winner_team = winner_team
+    else:
+        match_history.winner_team = parse_winner_team(form.get('winner_team'))
+
+    return True, None
+
+
 @app.route('/admin/match_history/<int:match_history_id>/score', methods=['POST'])
 def update_match_history_score(match_history_id):
     match_history = db.session.get(MatchHistory, match_history_id)
@@ -965,35 +1021,35 @@ def update_match_history_score(match_history_id):
         flash('指定された試合履歴が見つかりません')
         return redirect(url_for('admin_match_history'))
 
-    config = load_config()
-    score_input_mode = config["score_input_mode"]
-
-    if score_input_mode == "score":
-        dropdown_valid, posted_score_text, dropdown_error = build_score_text_from_dropdowns(
-            request.form,
-            config["scoring_system"]["games_per_match"],
-        )
-        if not dropdown_valid:
-            flash(dropdown_error or 'ゲーム別スコアを正しく入力してください')
-            return redirect(url_for('admin_match_history'))
-        valid, score_text, team1_score, team2_score, winner_team_or_error = parse_score_text(
-            posted_score_text,
-            config["scoring_system"],
-        )
-        if not valid:
-            flash(winner_team_or_error or 'ゲーム別スコアを正しく入力してください')
-            return redirect(url_for('admin_match_history'))
-        winner_team = winner_team_or_error
-        match_history.score_text = score_text
-        match_history.team1_score = team1_score
-        match_history.team2_score = team2_score
-        match_history.winner_team = winner_team
-    else:
-        match_history.winner_team = parse_winner_team(request.form.get('winner_team'))
+    updated, error_message = apply_match_history_score_update(match_history, request.form)
+    if not updated:
+        flash(error_message)
+        return redirect(url_for('admin_match_history'))
 
     db.session.commit()
     flash('試合結果を保存しました')
     return redirect(url_for('admin_match_history'))
+
+
+@app.route('/match/result/<int:match_history_id>/score', methods=['POST'])
+def update_match_result_score(match_history_id):
+    mode = request.form.get('mode', request.args.get('mode', 'admin'))
+    if mode != 'admin':
+        return redirect(url_for('match_result', mode='viewer'))
+
+    match_history = db.session.get(MatchHistory, match_history_id)
+    if match_history is None:
+        flash('指定された試合履歴が見つかりません')
+        return redirect(url_for('match_result', mode='admin'))
+
+    updated, error_message = apply_match_history_score_update(match_history, request.form)
+    if not updated:
+        flash(error_message)
+        return redirect(url_for('match_result', mode='admin'))
+
+    db.session.commit()
+    flash('試合結果を保存しました')
+    return redirect(url_for('match_result', mode='admin'))
 
 @app.route('/admin/match_history')
 def admin_match_history():

--- a/app.py
+++ b/app.py
@@ -74,9 +74,55 @@ ALL_CARDS = [
 ] + ['JOKER_RED', 'JOKER_BLACK']
 
     
+VALID_SCORE_INPUT_MODES = {"winner_only", "score"}
+DEFAULT_SCORE_INPUT_MODE = "winner_only"
+DEFAULT_SCORING_SYSTEM = {"points_per_game": 21, "games_per_match": 1}
+
+
+def parse_positive_int(value, default):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def normalize_score_input_mode(value):
+    if value in VALID_SCORE_INPUT_MODES:
+        return value
+    return DEFAULT_SCORE_INPUT_MODE
+
+
+def normalize_scoring_system(value):
+    if not isinstance(value, dict):
+        value = {}
+    return {
+        "points_per_game": parse_positive_int(
+            value.get("points_per_game"),
+            DEFAULT_SCORING_SYSTEM["points_per_game"],
+        ),
+        "games_per_match": parse_positive_int(
+            value.get("games_per_match"),
+            DEFAULT_SCORING_SYSTEM["games_per_match"],
+        ),
+    }
+
+
+def normalize_config(config):
+    if not isinstance(config, dict):
+        config = {}
+    normalized = dict(config)
+    normalized["score_input_mode"] = normalize_score_input_mode(config.get("score_input_mode"))
+    normalized["scoring_system"] = normalize_scoring_system(config.get("scoring_system"))
+    normalized.setdefault("paypay_links", {})
+    normalized.setdefault("level_map", {})
+    normalized.setdefault("gender_weight", {})
+    return normalized
+
+
 def load_config():
     with open('config.json', 'r', encoding='utf-8') as f:
-        return json.load(f)
+        return normalize_config(json.load(f))
     
 config = load_config()
 LEVEL_MAP = config.get("level_map", {})
@@ -662,10 +708,18 @@ def reset_match():
     flash('試合状態をリセットしました')
     return redirect(url_for('match_form'))
 
+def parse_float(value, default):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @app.route('/admin/settings', methods=['GET', 'POST'])
 def admin_settings():
     #if request.args.get('key') != 'supersecret':
     #    abort(403)  # Forbidden
+    current_config = load_config()
     if request.method == 'POST':
         # configの保存処理
         config = {
@@ -674,24 +728,26 @@ def admin_settings():
                 "students": request.form.get('paypay_students')
             },
             "level_map": {
-                "beginner": int(request.form.get('level_beginner')),
-                "intermediate": int(request.form.get('level_intermediate')),
-                "advanced": int(request.form.get('level_advanced'))
+                "beginner": parse_positive_int(request.form.get('level_beginner'), current_config["level_map"].get("beginner", 1)),
+                "intermediate": parse_positive_int(request.form.get('level_intermediate'), current_config["level_map"].get("intermediate", 2)),
+                "advanced": parse_positive_int(request.form.get('level_advanced'), current_config["level_map"].get("advanced", 3))
             },
             "gender_weight": {
-                "male": float(request.form.get('weight_male')),
-                "female": float(request.form.get('weight_female'))
-            }
+                "male": parse_float(request.form.get('weight_male'), current_config["gender_weight"].get("male", 1.0)),
+                "female": parse_float(request.form.get('weight_female'), current_config["gender_weight"].get("female", 0.9))
+            },
+            "score_input_mode": normalize_score_input_mode(request.form.get('score_input_mode')),
+            "scoring_system": normalize_scoring_system({
+                "points_per_game": request.form.get('points_per_game'),
+                "games_per_match": request.form.get('games_per_match'),
+            }),
         }
-        with open('config.json', 'w') as f:
-            json.dump(config, f, indent=4)
+        with open('config.json', 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=4, ensure_ascii=False)
         flash('設定を保存しました')
         return redirect(url_for('admin_settings'))
 
-    # GET時: 現在のconfigを読み込み
-    with open('config.json') as f:
-        config = json.load(f)
-    return render_template('admin_settings.html', config=config)
+    return render_template('admin_settings.html', config=current_config)
 
 @app.route('/admin/reset_db', methods=['POST'])
 def reset_db():
@@ -739,6 +795,51 @@ def get_participant_label_map(rounds):
     return {participant.id: format_participant_label(participant) for participant in participants}
 
 
+
+
+def parse_optional_int(value):
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_winner_team(value):
+    winner = parse_optional_int(value)
+    return winner if winner in (1, 2) else None
+
+
+@app.route('/admin/match_history/<int:match_history_id>/score', methods=['POST'])
+def update_match_history_score(match_history_id):
+    match_history = db.session.get(MatchHistory, match_history_id)
+    if match_history is None:
+        flash('指定された試合履歴が見つかりません')
+        return redirect(url_for('admin_match_history'))
+
+    score_input_mode = load_config()["score_input_mode"]
+    winner_team = parse_winner_team(request.form.get('winner_team'))
+
+    if score_input_mode == "score":
+        team1_score = parse_optional_int(request.form.get('team1_score'))
+        team2_score = parse_optional_int(request.form.get('team2_score'))
+        match_history.team1_score = team1_score
+        match_history.team2_score = team2_score
+        if winner_team is None and team1_score is not None and team2_score is not None:
+            if team1_score > team2_score:
+                winner_team = 1
+            elif team2_score > team1_score:
+                winner_team = 2
+        match_history.winner_team = winner_team
+    else:
+        match_history.winner_team = winner_team
+
+    db.session.commit()
+    flash('試合結果を保存しました')
+    return redirect(url_for('admin_match_history'))
+
+
 @app.route('/admin/match_history')
 def admin_match_history():
     rounds = (
@@ -756,6 +857,8 @@ def admin_match_history():
         'match_history.html',
         rounds=rounds,
         participant_labels=participant_labels,
+        score_input_mode=load_config()["score_input_mode"],
+        scoring_system=load_config()["scoring_system"],
     )
 
 # 管理者向けトップページ

--- a/app.py
+++ b/app.py
@@ -879,6 +879,47 @@ def decide_game_winner(left_score, right_score, scoring_system):
     return 1 if left_score > right_score else 2
 
 
+
+def parse_score_text_rows(score_text, games_per_match):
+    rows = []
+    for raw_line in (score_text or '').splitlines():
+        line = raw_line.strip()
+        if line == '':
+            continue
+        match = GAME_SCORE_RE.match(line)
+        if match is None:
+            continue
+        rows.append({
+            "team1": match.group(1),
+            "team2": match.group(2),
+        })
+        if len(rows) >= games_per_match:
+            break
+    while len(rows) < games_per_match:
+        rows.append({"team1": "", "team2": ""})
+    return rows
+
+
+def build_score_text_from_dropdowns(form, games_per_match):
+    dropdown_field_names = {
+        f"game{game_number}_{team}_score"
+        for game_number in range(1, games_per_match + 1)
+        for team in ("team1", "team2")
+    }
+    if not dropdown_field_names.intersection(form.keys()) and "score_text" in form:
+        return True, form.get("score_text"), None
+
+    lines = []
+    for game_number in range(1, games_per_match + 1):
+        team1_value = (form.get(f"game{game_number}_team1_score") or '').strip()
+        team2_value = (form.get(f"game{game_number}_team2_score") or '').strip()
+        if team1_value == '' and team2_value == '':
+            continue
+        if team1_value == '' or team2_value == '':
+            return False, None, '片方だけ未入力のゲームがあります'
+        lines.append(f"{team1_value}-{team2_value}")
+    return True, "\n".join(lines), None
+
 def parse_score_text(score_text, scoring_system):
     normalized_text = (score_text or "").strip()
     if normalized_text == "":
@@ -928,8 +969,15 @@ def update_match_history_score(match_history_id):
     score_input_mode = config["score_input_mode"]
 
     if score_input_mode == "score":
+        dropdown_valid, posted_score_text, dropdown_error = build_score_text_from_dropdowns(
+            request.form,
+            config["scoring_system"]["games_per_match"],
+        )
+        if not dropdown_valid:
+            flash(dropdown_error or 'ゲーム別スコアを正しく入力してください')
+            return redirect(url_for('admin_match_history'))
         valid, score_text, team1_score, team2_score, winner_team_or_error = parse_score_text(
-            request.form.get('score_text'),
+            posted_score_text,
             config["scoring_system"],
         )
         if not valid:
@@ -960,12 +1008,20 @@ def admin_match_history():
     )
     participant_labels = get_participant_label_map(rounds)
 
+    config = load_config()
+    scoring_system = config["scoring_system"]
     return render_template(
         'match_history.html',
         rounds=rounds,
         participant_labels=participant_labels,
-        score_input_mode=load_config()["score_input_mode"],
-        scoring_system=load_config()["scoring_system"],
+        score_input_mode=config["score_input_mode"],
+        scoring_system=scoring_system,
+        score_options=list(range(scoring_system["max_points"] + 1)),
+        score_rows_by_match_id={
+            match.id: parse_score_text_rows(match.score_text, scoring_system["games_per_match"])
+            for match_round in rounds
+            for match in match_round.matches
+        },
     )
 
 # 管理者向けトップページ

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from models import db, Participant, MatchRound, MatchHistory, BenchHistory
 from flask import flash
 from flask import Response
 from sqlalchemy import inspect, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import selectinload
 from flask import send_from_directory
 from flask import send_file
@@ -67,6 +68,12 @@ def ensure_database_tables():
         ensure_match_history_score_text_column()
 
 
+def is_duplicate_score_text_column_error(error):
+    """Return True when SQLite reports score_text was already added."""
+    message = str(getattr(error, "orig", error)).lower()
+    return "duplicate column" in message and "score_text" in message
+
+
 def ensure_match_history_score_text_column():
     """Add score_text to existing SQLite match history tables when missing."""
     inspector = inspect(db.engine)
@@ -74,8 +81,14 @@ def ensure_match_history_score_text_column():
         return
     column_names = {column["name"] for column in inspector.get_columns(MatchHistory.__tablename__)}
     if "score_text" not in column_names:
-        db.session.execute(text("ALTER TABLE match_histories ADD COLUMN score_text TEXT"))
-        db.session.commit()
+        try:
+            db.session.execute(text("ALTER TABLE match_histories ADD COLUMN score_text TEXT"))
+            db.session.commit()
+        except OperationalError as error:
+            db.session.rollback()
+            if is_duplicate_score_text_column_error(error):
+                return
+            raise
 
 
 ensure_database_tables()

--- a/config.example.json
+++ b/config.example.json
@@ -11,5 +11,10 @@
   "gender_weight": {
     "male": 1.0,
     "female": 0.9
+  },
+  "score_input_mode": "winner_only",
+  "scoring_system": {
+    "points_per_game": 21,
+    "games_per_match": 1
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -15,6 +15,8 @@
   "score_input_mode": "winner_only",
   "scoring_system": {
     "points_per_game": 21,
-    "games_per_match": 1
+    "games_per_match": 1,
+    "deuce_enabled": false,
+    "max_points": 21
   }
 }

--- a/models.py
+++ b/models.py
@@ -43,6 +43,7 @@ class MatchHistory(db.Model):
     team2_player2_id = db.Column(db.Integer, db.ForeignKey('participants.id'), nullable=False)
     team1_score = db.Column(db.Integer, nullable=True)
     team2_score = db.Column(db.Integer, nullable=True)
+    score_text = db.Column(db.Text, nullable=True)
     winner_team = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -46,7 +46,16 @@
     <br>
     <label>ゲーム数</label>
     <input type="number" name="games_per_match" min="1" value="{{ config.scoring_system.games_per_match }}">
-    <p>例: {{ config.scoring_system.points_per_game }}ポイント × {{ config.scoring_system.games_per_match }}ゲーム</p>
+    <br>
+    <label>デュース</label>
+    <select name="deuce_enabled">
+        <option value="" {% if not config.scoring_system.deuce_enabled %}selected{% endif %}>デュースなし</option>
+        <option value="on" {% if config.scoring_system.deuce_enabled %}selected{% endif %}>デュースあり</option>
+    </select>
+    <br>
+    <label>最大ポイント</label>
+    <input type="number" name="max_points" min="1" value="{{ config.scoring_system.max_points }}">
+    <p>例: {{ config.scoring_system.points_per_game }}ポイント × {{ config.scoring_system.games_per_match }}ゲーム（最大{{ config.scoring_system.max_points }}ポイント）</p>
     <br>
     <button type="submit">💾 設定を保存</button>
 </form>

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -32,7 +32,22 @@
     <br>
     <label>female</label>
     <input type="text" name="weight_female" value="{{ config.gender_weight.female }}">
-    <br><br>
+    <hr>
+
+    <h3>勝敗・スコア入力設定</h3>
+    <label>勝敗・スコア入力モード</label>
+    <select name="score_input_mode">
+        <option value="winner_only" {% if config.score_input_mode == 'winner_only' %}selected{% endif %}>勝敗だけ入力</option>
+        <option value="score" {% if config.score_input_mode == 'score' %}selected{% endif %}>スコアを入力</option>
+    </select>
+    <br>
+    <label>1ゲームのポイント数</label>
+    <input type="number" name="points_per_game" min="1" value="{{ config.scoring_system.points_per_game }}">
+    <br>
+    <label>ゲーム数</label>
+    <input type="number" name="games_per_match" min="1" value="{{ config.scoring_system.games_per_match }}">
+    <p>例: {{ config.scoring_system.points_per_game }}ポイント × {{ config.scoring_system.games_per_match }}ゲーム</p>
+    <br>
     <button type="submit">💾 設定を保存</button>
 </form>
 

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -102,11 +102,11 @@
                                 {% endif %}
                             {% else %}
                                 {% if match.team1_score is not none and match.team2_score is not none %}
-                                    {{ match.team1_score }} - {{ match.team2_score }}
+                                    ゲームカウント: {{ match.team1_score }} - {{ match.team2_score }}
                                     {% if match.winner_team == 1 or match.winner_team == 2 %}
                                         / 勝者: team{{ match.winner_team }}
                                     {% else %}
-                                        / 勝者未入力
+                                        / 引き分け
                                     {% endif %}
                                 {% elif match.winner_team == 1 or match.winner_team == 2 %}
                                     team{{ match.winner_team }} 勝利
@@ -117,20 +117,20 @@
                         </div>
                         <form method="post" action="{{ url_for('update_match_history_score', match_history_id=match.id) }}" class="score-form">
                             {% if score_input_mode == 'score' %}
-                                <label>team1_score
-                                    <input type="number" name="team1_score" min="0" value="{{ '' if match.team1_score is none else match.team1_score }}">
+                                <label>ゲーム別スコア
+                                    <textarea name="score_text" rows="4" placeholder="21-15
+10-21
+22-20">{{ match.score_text or '' }}</textarea>
                                 </label>
-                                <label>team2_score
-                                    <input type="number" name="team2_score" min="0" value="{{ '' if match.team2_score is none else match.team2_score }}">
+                            {% else %}
+                                <label>winner_team
+                                    <select name="winner_team">
+                                        <option value="" {% if match.winner_team is none %}selected{% endif %}>未入力</option>
+                                        <option value="1" {% if match.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
+                                        <option value="2" {% if match.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
+                                    </select>
                                 </label>
                             {% endif %}
-                            <label>winner_team
-                                <select name="winner_team">
-                                    <option value="" {% if match.winner_team is none %}selected{% endif %}>未入力</option>
-                                    <option value="1" {% if match.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
-                                    <option value="2" {% if match.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
-                                </select>
-                            </label>
                             <button type="submit">結果を保存</button>
                         </form>
                     </div>

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -48,8 +48,21 @@
             align-items: center;
         }
 
-        .score-form input {
+        .score-form input,
+        .score-form select {
             width: 5em;
+        }
+
+        .score-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+            margin: 4px 0;
+        }
+
+        .saved-score-text {
+            white-space: pre-line;
+            margin-top: 4px;
         }
 
         .empty-message {
@@ -108,8 +121,14 @@
                                     {% else %}
                                         / 引き分け
                                     {% endif %}
+                                    {% if match.score_text %}
+                                        <div class="saved-score-text">{{ match.score_text }}</div>
+                                    {% endif %}
                                 {% elif match.winner_team == 1 or match.winner_team == 2 %}
                                     team{{ match.winner_team }} 勝利
+                                    {% if match.score_text %}
+                                        <div class="saved-score-text">{{ match.score_text }}</div>
+                                    {% endif %}
                                 {% else %}
                                     結果未入力
                                 {% endif %}
@@ -117,11 +136,26 @@
                         </div>
                         <form method="post" action="{{ url_for('update_match_history_score', match_history_id=match.id) }}" class="score-form">
                             {% if score_input_mode == 'score' %}
-                                <label>ゲーム別スコア
-                                    <textarea name="score_text" rows="4" placeholder="21-15
-10-21
-22-20">{{ match.score_text or '' }}</textarea>
-                                </label>
+                                <div>ゲーム別スコア</div>
+                                <div>
+                                    {% for score_row in score_rows_by_match_id.get(match.id, []) %}
+                                        <div class="score-row">
+                                            <select name="game{{ loop.index }}_team1_score" aria-label="第{{ loop.index }}ゲーム team1 スコア">
+                                                <option value="" {% if score_row.team1 == '' %}selected{% endif %}></option>
+                                                {% for score_option in score_options %}
+                                                    <option value="{{ score_option }}" {% if score_row.team1 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
+                                                {% endfor %}
+                                            </select>
+                                            <span>−</span>
+                                            <select name="game{{ loop.index }}_team2_score" aria-label="第{{ loop.index }}ゲーム team2 スコア">
+                                                <option value="" {% if score_row.team2 == '' %}selected{% endif %}></option>
+                                                {% for score_option in score_options %}
+                                                    <option value="{{ score_option }}" {% if score_row.team2 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    {% endfor %}
+                                </div>
                             {% else %}
                                 <label>winner_team
                                     <select name="winner_team">

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -40,6 +40,18 @@
             margin-top: 4px;
         }
 
+        .score-form {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 8px;
+            align-items: center;
+        }
+
+        .score-form input {
+            width: 5em;
+        }
+
         .empty-message {
             color: #666;
             font-size: 18px;
@@ -57,6 +69,7 @@
     </style>
 </head>
 <body>
+    {% include "_flash_messages.html" %}
     <h1>試合履歴</h1>
     <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a></p>
 
@@ -85,6 +98,24 @@
                                 {{ match.team1_score }} - {{ match.team2_score }} / 勝者: team{{ match.winner_team }}
                             {% endif %}
                         </div>
+                        <form method="post" action="{{ url_for('update_match_history_score', match_history_id=match.id) }}" class="score-form">
+                            {% if score_input_mode == 'score' %}
+                                <label>team1_score
+                                    <input type="number" name="team1_score" min="0" value="{{ '' if match.team1_score is none else match.team1_score }}">
+                                </label>
+                                <label>team2_score
+                                    <input type="number" name="team2_score" min="0" value="{{ '' if match.team2_score is none else match.team2_score }}">
+                                </label>
+                            {% endif %}
+                            <label>winner_team
+                                <select name="winner_team">
+                                    <option value="" {% if match.winner_team is none %}selected{% endif %}>未入力</option>
+                                    <option value="1" {% if match.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
+                                    <option value="2" {% if match.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
+                                </select>
+                            </label>
+                            <button type="submit">結果を保存</button>
+                        </form>
                     </div>
                 {% endfor %}
 

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -92,10 +92,27 @@
                             {{ participant_labels.get(match.team2_player1_id, '[]不明な参加者') }}・{{ participant_labels.get(match.team2_player2_id, '[]不明な参加者') }}
                         </div>
                         <div class="score-status">
-                            {% if match.team1_score is none or match.team2_score is none or match.winner_team is none %}
-                                結果未入力
+                            {% if score_input_mode == 'winner_only' %}
+                                {% if match.winner_team == 1 %}
+                                    team1 勝利
+                                {% elif match.winner_team == 2 %}
+                                    team2 勝利
+                                {% else %}
+                                    結果未入力
+                                {% endif %}
                             {% else %}
-                                {{ match.team1_score }} - {{ match.team2_score }} / 勝者: team{{ match.winner_team }}
+                                {% if match.team1_score is not none and match.team2_score is not none %}
+                                    {{ match.team1_score }} - {{ match.team2_score }}
+                                    {% if match.winner_team == 1 or match.winner_team == 2 %}
+                                        / 勝者: team{{ match.winner_team }}
+                                    {% else %}
+                                        / 勝者未入力
+                                    {% endif %}
+                                {% elif match.winner_team == 1 or match.winner_team == 2 %}
+                                    team{{ match.winner_team }} 勝利
+                                {% else %}
+                                    結果未入力
+                                {% endif %}
                             {% endif %}
                         </div>
                         <form method="post" action="{{ url_for('update_match_history_score', match_history_id=match.id) }}" class="score-form">

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -62,7 +62,40 @@
             font-weight: bold;
             margin: 5px 0;
         }
+
+        .score-status {
+            color: #555;
+            font-size: 14px;
+            margin-top: 10px;
+        }
+
+        .score-form {
+            border-top: 1px solid #ddd;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 10px;
+            padding-top: 10px;
+        }
+
+        .score-row {
+            align-items: center;
+            display: flex;
+            gap: 6px;
+            justify-content: center;
+            margin: 4px 0;
+        }
+
+        .score-row select {
+            width: 5em;
+        }
+
+        .saved-score-text {
+            white-space: pre-line;
+            margin-top: 4px;
+        }
     </style>
+    {% include "_flash_messages.html" %}
     {% if is_draft %}
         <h1>次の組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
         <div style="background-color: #fff3cd; color: #856404; padding: 12px; border-radius: 6px; border: 1px solid #ffeeba; font-weight: bold; margin-bottom: 12px;">
@@ -94,8 +127,10 @@
         <div class="court-scroll-container">
             <div class="court-list">
                 {% for match in matches %}
+                    {% set court_number = loop.index %}
+                    {% set match_history = match_histories_by_court.get(court_number) %}
                     <div class="court">
-                        <h3>コート {{ loop.index }}</h3>
+                        <h3>コート {{ court_number }}</h3>
                         <!-- 上段 -->
                         <div class="players-row">
                             {% for p in match[:2] %}
@@ -115,6 +150,76 @@
                                 </div>
                             {% endfor %}
                         </div>
+                        {% if mode == 'admin' and not is_draft %}
+                            {% if match_history %}
+                                <div class="score-status">
+                                    {% if score_input_mode == 'winner_only' %}
+                                        {% if match_history.winner_team == 1 %}
+                                            team1 勝利
+                                        {% elif match_history.winner_team == 2 %}
+                                            team2 勝利
+                                        {% else %}
+                                            結果未入力
+                                        {% endif %}
+                                    {% else %}
+                                        {% if match_history.team1_score is not none and match_history.team2_score is not none %}
+                                            ゲームカウント: {{ match_history.team1_score }} - {{ match_history.team2_score }}
+                                            {% if match_history.winner_team == 1 or match_history.winner_team == 2 %}
+                                                / 勝者: team{{ match_history.winner_team }}
+                                            {% else %}
+                                                / 引き分け
+                                            {% endif %}
+                                            {% if match_history.score_text %}
+                                                <div class="saved-score-text">{{ match_history.score_text }}</div>
+                                            {% endif %}
+                                        {% elif match_history.winner_team == 1 or match_history.winner_team == 2 %}
+                                            team{{ match_history.winner_team }} 勝利
+                                            {% if match_history.score_text %}
+                                                <div class="saved-score-text">{{ match_history.score_text }}</div>
+                                            {% endif %}
+                                        {% else %}
+                                            結果未入力
+                                        {% endif %}
+                                    {% endif %}
+                                </div>
+                                <form method="post" action="{{ url_for('update_match_result_score', match_history_id=match_history.id) }}" class="score-form">
+                                    <input type="hidden" name="mode" value="admin">
+                                    {% if score_input_mode == 'score' %}
+                                        <div>ゲーム別スコア</div>
+                                        <div>
+                                            {% for score_row in score_rows_by_match_id.get(match_history.id, []) %}
+                                                <div class="score-row">
+                                                    <select name="game{{ loop.index }}_team1_score" aria-label="第{{ loop.index }}ゲーム team1 スコア">
+                                                        <option value="" {% if score_row.team1 == '' %}selected{% endif %}></option>
+                                                        {% for score_option in score_options %}
+                                                            <option value="{{ score_option }}" {% if score_row.team1 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
+                                                        {% endfor %}
+                                                    </select>
+                                                    <span>−</span>
+                                                    <select name="game{{ loop.index }}_team2_score" aria-label="第{{ loop.index }}ゲーム team2 スコア">
+                                                        <option value="" {% if score_row.team2 == '' %}selected{% endif %}></option>
+                                                        {% for score_option in score_options %}
+                                                            <option value="{{ score_option }}" {% if score_row.team2 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
+                                                        {% endfor %}
+                                                    </select>
+                                                </div>
+                                            {% endfor %}
+                                        </div>
+                                    {% else %}
+                                        <label>winner_team
+                                            <select name="winner_team">
+                                                <option value="" {% if match_history.winner_team is none %}selected{% endif %}>未入力</option>
+                                                <option value="1" {% if match_history.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
+                                                <option value="2" {% if match_history.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
+                                            </select>
+                                        </label>
+                                    {% endif %}
+                                    <button type="submit">結果を保存</button>
+                                </form>
+                            {% else %}
+                                <div class="score-status">対応する試合履歴が見つかりません</div>
+                            {% endif %}
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -3,6 +3,8 @@ import json
 import os
 import sys
 
+import pytest
+
 
 def load_history_test_app(monkeypatch, tmp_path):
     config = {"level_map": {}, "gender_weight": {}}
@@ -653,3 +655,85 @@ def test_ensure_database_tables_adds_score_text_column_without_deleting_rows(mon
 
         assert "score_text" in columns
         assert row_count == 1
+
+
+
+def create_match_histories_table_without_score_text(app_module):
+    app_module.db.session.execute(app_module.text("DROP TABLE match_histories"))
+    app_module.db.session.execute(app_module.text("""
+        CREATE TABLE match_histories (
+            id INTEGER PRIMARY KEY,
+            round_id INTEGER NOT NULL,
+            court_number INTEGER NOT NULL,
+            team1_player1_id INTEGER NOT NULL,
+            team1_player2_id INTEGER NOT NULL,
+            team2_player1_id INTEGER NOT NULL,
+            team2_player2_id INTEGER NOT NULL,
+            team1_score INTEGER,
+            team2_score INTEGER,
+            winner_team INTEGER,
+            created_at DATETIME NOT NULL
+        )
+    """))
+    app_module.db.session.commit()
+
+
+def test_ensure_score_text_column_is_noop_when_column_exists(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        app_module.ensure_match_history_score_text_column()
+        columns = {column["name"] for column in app_module.inspect(app_module.db.engine).get_columns("match_histories")}
+
+        assert "score_text" in columns
+
+
+def test_ensure_score_text_column_allows_parallel_duplicate_column_error(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        create_match_histories_table_without_score_text(app_module)
+        rollback_called = {"value": False}
+
+        def raise_duplicate_column(_statement):
+            raise app_module.OperationalError(
+                "ALTER TABLE match_histories ADD COLUMN score_text TEXT",
+                {},
+                Exception("duplicate column name: score_text"),
+            )
+
+        def mark_rollback():
+            rollback_called["value"] = True
+
+        monkeypatch.setattr(app_module.db.session, "execute", raise_duplicate_column)
+        monkeypatch.setattr(app_module.db.session, "rollback", mark_rollback)
+
+        app_module.ensure_match_history_score_text_column()
+
+        assert rollback_called["value"] is True
+
+
+def test_ensure_score_text_column_reraises_non_duplicate_operational_error(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        create_match_histories_table_without_score_text(app_module)
+        rollback_called = {"value": False}
+
+        def raise_other_operational_error(_statement):
+            raise app_module.OperationalError(
+                "ALTER TABLE match_histories ADD COLUMN score_text TEXT",
+                {},
+                Exception("database is locked"),
+            )
+
+        def mark_rollback():
+            rollback_called["value"] = True
+
+        monkeypatch.setattr(app_module.db.session, "execute", raise_other_operational_error)
+        monkeypatch.setattr(app_module.db.session, "rollback", mark_rollback)
+
+        with pytest.raises(app_module.OperationalError):
+            app_module.ensure_match_history_score_text_column()
+
+        assert rollback_called["value"] is True

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -243,6 +243,7 @@ def test_confirm_rolls_back_db_when_clearing_draft_fails(monkeypatch, tmp_path):
 
 def test_admin_match_history_page_displays_round_matches_bench_and_scores(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
 
     with app_module.app.app_context():
         add_participants(app_module, 9)
@@ -289,7 +290,8 @@ def test_admin_match_history_page_displays_round_matches_bench_and_scores(monkey
         assert "[C7]player-7・[C8]player-8" in html
         assert "[C9]player-9" in html
         assert "結果未入力" in html
-        assert "21 - 18 / 勝者: team1" in html
+        assert "21 - 18" in html
+        assert "勝者: team1" in html
 
 
 def test_admin_match_history_page_formats_special_and_missing_participant_cards(monkeypatch, tmp_path):
@@ -516,7 +518,7 @@ def test_score_mode_updates_scores_allows_blank_partial_and_invalid(monkeypatch,
             "team1_score": "abc", "team2_score": "20", "winner_team": ""
         })
         match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 20, None)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 12, None)
 
 
 def test_invalid_match_history_id_redirects_without_error(monkeypatch, tmp_path):
@@ -543,3 +545,107 @@ def test_match_history_input_ui_switches_by_score_mode(monkeypatch, tmp_path):
         assert "winner_team" in score_html
         assert "team1_score" in score_html
         assert "ベンチ" in score_html
+
+
+def test_winner_only_history_display_uses_winner_team_without_scores(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 12)
+        round_record = app_module.MatchRound(round_number=1)
+        app_module.db.session.add(round_record)
+        app_module.db.session.flush()
+        for index, winner_team in enumerate((1, 2, None)):
+            player_offset = index * 4
+            app_module.db.session.add(app_module.MatchHistory(
+                round_id=round_record.id,
+                court_number=index + 1,
+                team1_player1_id=player_offset + 1,
+                team1_player2_id=player_offset + 2,
+                team2_player1_id=player_offset + 3,
+                team2_player2_id=player_offset + 4,
+                winner_team=winner_team,
+            ))
+        app_module.db.session.commit()
+
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert "team1 勝利" in html
+        assert "team2 勝利" in html
+        assert "結果未入力" in html
+
+
+def test_score_mode_rejects_invalid_scores_without_changing_existing_values(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 1},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, 10, 8, 1)
+        client = app_module.app.test_client()
+
+        invalid_posts = [
+            {"team1_score": "-1", "team2_score": "8", "winner_team": "2"},
+            {"team1_score": "100000000000000000000000000000000000000000000000000", "team2_score": "8", "winner_team": "2"},
+            {"team1_score": "abc", "team2_score": "8", "winner_team": "2"},
+        ]
+        for data in invalid_posts:
+            response = client.post(f"/admin/match_history/{match_id}/score", data=data)
+            assert response.status_code == 302
+            match = app_module.db.session.get(app_module.MatchHistory, match_id)
+            assert (match.team1_score, match.team2_score, match.winner_team) == (10, 8, 1)
+
+
+def test_score_mode_accepts_scores_within_configured_range(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 15, "games_per_match": 3},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, None, None, None)
+        response = app_module.app.test_client().post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "45", "team2_score": "44", "winner_team": "1",
+        })
+
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (45, 44, 1)
+
+
+def test_score_mode_honors_posted_winner_selection(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, 21, 15, 1)
+        client = app_module.app.test_client()
+
+        response = client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "21", "team2_score": "15", "winner_team": "",
+        })
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (21, 15, None)
+
+        client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "21", "team2_score": "15", "winner_team": "1",
+        })
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.winner_team == 1
+
+        client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "21", "team2_score": "15", "winner_team": "2",
+        })
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.winner_team == 2
+
+        response = client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "21", "team2_score": "15", "winner_team": "bad",
+        })
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.winner_team is None

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -842,3 +842,146 @@ def test_ensure_score_text_column_reraises_non_duplicate_operational_error(monke
             app_module.ensure_match_history_score_text_column()
 
         assert rollback_called["value"] is True
+
+
+def add_result_page_fixture(app_module, tmp_path, *, score_text=None, team1_score=None, team2_score=None, winner_team=None):
+    cards = ["♥A", "♦A", "♣A", "♠A"]
+    for player_id, card in enumerate(cards, start=1):
+        app_module.db.session.add(app_module.Participant(
+            id=player_id,
+            name=f"player-{player_id}",
+            gender="male",
+            level="beginner",
+            weight=1.0,
+            card=card,
+        ))
+    round_record = app_module.MatchRound(round_number=1)
+    app_module.db.session.add(round_record)
+    app_module.db.session.flush()
+    match = app_module.MatchHistory(
+        round_id=round_record.id,
+        court_number=1,
+        team1_player1_id=1,
+        team1_player2_id=2,
+        team2_player1_id=3,
+        team2_player2_id=4,
+        score_text=score_text,
+        team1_score=team1_score,
+        team2_score=team2_score,
+        winner_team=winner_team,
+    )
+    app_module.db.session.add(match)
+    app_module.db.session.commit()
+    (tmp_path / "match_state.json").write_text(json.dumps({
+        "match_active": True,
+        "match_count": 1,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [],
+        "court_count": 1,
+    }), encoding="utf-8")
+    return match.id
+
+
+def test_admin_match_result_shows_score_form_but_viewer_does_not(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        add_result_page_fixture(app_module, tmp_path)
+        client = app_module.app.test_client()
+
+        admin_html = client.get("/match/result?mode=admin").get_data(as_text=True)
+        viewer_html = client.get("/match/result?mode=viewer").get_data(as_text=True)
+
+        assert "結果を保存" in admin_html
+        assert "winner_team" in admin_html
+        assert "結果を保存" not in viewer_html
+        assert "winner_team" not in viewer_html
+
+
+def test_admin_match_result_winner_only_saves_latest_court_history(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_result_page_fixture(app_module, tmp_path, team1_score=1, team2_score=0, winner_team=None)
+        response = app_module.app.test_client().post(f"/match/result/{match_id}/score", data={"mode": "admin", "winner_team": "2"})
+
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/match/result?mode=admin")
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.winner_team == 2
+        assert match.team1_score == 1
+        assert match.team2_score == 0
+
+
+def test_admin_match_result_score_dropdown_saves_and_redisplays(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": True, "max_points": 30},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_result_page_fixture(app_module, tmp_path)
+        client = app_module.app.test_client()
+        response = client.post(f"/match/result/{match_id}/score", data={
+            "mode": "admin",
+            "game1_team1_score": "21",
+            "game1_team2_score": "15",
+            "game2_team1_score": "10",
+            "game2_team2_score": "21",
+            "game3_team1_score": "22",
+            "game3_team2_score": "20",
+        })
+
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.score_text == "21-15\n10-21\n22-20"
+        assert (match.team1_score, match.team2_score, match.winner_team) == (2, 1, 1)
+
+        html = client.get("/match/result?mode=admin").get_data(as_text=True)
+        assert "ゲームカウント: 2 - 1" in html
+        assert "21-15" in html
+        assert 'name="game1_team1_score"' in html
+        assert 'value="22" selected' in html
+
+
+def test_admin_match_result_missing_history_does_not_500(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_result_page_fixture(app_module, tmp_path)
+        app_module.MatchHistory.query.delete()
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().get("/match/result?mode=admin")
+        html = response.get_data(as_text=True)
+
+        assert response.status_code == 200
+        assert "対応する試合履歴が見つかりません" in html
+        assert "結果を保存" not in html
+
+
+def test_admin_match_result_invalid_score_keeps_existing_value(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_result_page_fixture(app_module, tmp_path, score_text="21-15", team1_score=1, team2_score=0, winner_team=1)
+        response = app_module.app.test_client().post(f"/match/result/{match_id}/score", data={
+            "mode": "admin",
+            "game1_team1_score": "22",
+            "game1_team2_score": "20",
+            "game2_team1_score": "",
+            "game2_team2_score": "",
+            "game3_team1_score": "",
+            "game3_team2_score": "",
+        })
+
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == ("21-15", 1, 0, 1)

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -408,3 +408,138 @@ def test_admin_index_links_to_match_history_but_viewer_index_does_not(monkeypatc
         assert "試合履歴" in admin_html
         assert "/admin/match_history" not in viewer_html
         assert "試合履歴" not in viewer_html
+
+def test_score_config_defaults_and_invalid_values(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    assert app_module.load_config()["score_input_mode"] == "winner_only"
+    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1}
+
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "bad",
+        "scoring_system": {"points_per_game": "bad", "games_per_match": 0},
+    }), encoding="utf-8")
+
+    assert app_module.load_config()["score_input_mode"] == "winner_only"
+    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1}
+
+
+def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    client = app_module.app.test_client()
+    html = client.get("/admin/settings").get_data(as_text=True)
+    assert "勝敗・スコア入力モード" in html
+    assert "1ゲームのポイント数" in html
+
+    response = client.post("/admin/settings", data={
+        "paypay_adults": "adults",
+        "paypay_students": "students",
+        "level_beginner": "1",
+        "level_intermediate": "2",
+        "level_advanced": "3",
+        "weight_male": "1.0",
+        "weight_female": "0.9",
+        "score_input_mode": "score",
+        "points_per_game": "15",
+        "games_per_match": "3",
+    })
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["score_input_mode"] == "score"
+    assert saved["scoring_system"] == {"points_per_game": 15, "games_per_match": 3}
+    assert saved["paypay_links"] == {"adults": "adults", "students": "students"}
+
+
+def add_history_match(app_module, team1_score=10, team2_score=8, winner_team=1):
+    add_participants(app_module, 4)
+    round_record = app_module.MatchRound(round_number=1)
+    app_module.db.session.add(round_record)
+    app_module.db.session.flush()
+    match = app_module.MatchHistory(
+        round_id=round_record.id,
+        court_number=1,
+        team1_player1_id=1,
+        team1_player2_id=2,
+        team2_player1_id=3,
+        team2_player2_id=4,
+        team1_score=team1_score,
+        team2_score=team2_score,
+        winner_team=winner_team,
+    )
+    app_module.db.session.add(match)
+    app_module.db.session.commit()
+    return match.id
+
+
+def test_winner_only_updates_winner_without_changing_scores(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module)
+        client = app_module.app.test_client()
+
+        for winner in ("2", "1", ""):
+            response = client.post(f"/admin/match_history/{match_id}/score", data={"winner_team": winner})
+            assert response.status_code == 302
+            assert response.headers["Location"].endswith("/admin/match_history")
+
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert match.winner_team is None
+        assert match.team1_score == 10
+        assert match.team2_score == 8
+
+
+def test_score_mode_updates_scores_allows_blank_partial_and_invalid(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, None, None, None)
+        client = app_module.app.test_client()
+
+        response = client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "21", "team2_score": "18", "winner_team": "1"
+        })
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (21, 18, 1)
+
+        client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "", "team2_score": "12", "winner_team": ""
+        })
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 12, None)
+
+        client.post(f"/admin/match_history/{match_id}/score", data={
+            "team1_score": "abc", "team2_score": "20", "winner_team": ""
+        })
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 20, None)
+
+
+def test_invalid_match_history_id_redirects_without_error(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().post("/admin/match_history/999/score", data={"winner_team": "1"})
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/admin/match_history")
+
+
+def test_match_history_input_ui_switches_by_score_mode(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_history_match(app_module)
+        client = app_module.app.test_client()
+        winner_html = client.get("/admin/match_history").get_data(as_text=True)
+        assert "winner_team" in winner_html
+        assert "team1_score" not in winner_html
+
+        (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
+        score_html = client.get("/admin/match_history").get_data(as_text=True)
+        assert "winner_team" in score_html
+        assert "team1_score" in score_html
+        assert "ベンチ" in score_html

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -415,7 +415,7 @@ def test_score_config_defaults_and_invalid_values(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
 
     assert app_module.load_config()["score_input_mode"] == "winner_only"
-    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1}
+    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": False, "max_points": 21}
 
     (tmp_path / "config.json").write_text(json.dumps({
         "score_input_mode": "bad",
@@ -423,7 +423,7 @@ def test_score_config_defaults_and_invalid_values(monkeypatch, tmp_path):
     }), encoding="utf-8")
 
     assert app_module.load_config()["score_input_mode"] == "winner_only"
-    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1}
+    assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": False, "max_points": 21}
 
 
 def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path):
@@ -445,12 +445,14 @@ def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path)
         "score_input_mode": "score",
         "points_per_game": "15",
         "games_per_match": "3",
+        "deuce_enabled": "on",
+        "max_points": "30",
     })
 
     assert response.status_code == 302
     saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
     assert saved["score_input_mode"] == "score"
-    assert saved["scoring_system"] == {"points_per_game": 15, "games_per_match": 3}
+    assert saved["scoring_system"] == {"points_per_game": 15, "games_per_match": 3, "deuce_enabled": True, "max_points": 30}
     assert saved["paypay_links"] == {"adults": "adults", "students": "students"}
 
 
@@ -493,34 +495,6 @@ def test_winner_only_updates_winner_without_changing_scores(monkeypatch, tmp_pat
         assert match.team2_score == 8
 
 
-def test_score_mode_updates_scores_allows_blank_partial_and_invalid(monkeypatch, tmp_path):
-    app_module = load_history_test_app(monkeypatch, tmp_path)
-    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
-
-    with app_module.app.app_context():
-        match_id = add_history_match(app_module, None, None, None)
-        client = app_module.app.test_client()
-
-        response = client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "21", "team2_score": "18", "winner_team": "1"
-        })
-        assert response.status_code == 302
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (21, 18, 1)
-
-        client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "", "team2_score": "12", "winner_team": ""
-        })
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 12, None)
-
-        client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "abc", "team2_score": "20", "winner_team": ""
-        })
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (None, 12, None)
-
-
 def test_invalid_match_history_id_redirects_without_error(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
 
@@ -542,8 +516,8 @@ def test_match_history_input_ui_switches_by_score_mode(monkeypatch, tmp_path):
 
         (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
         score_html = client.get("/admin/match_history").get_data(as_text=True)
-        assert "winner_team" in score_html
-        assert "team1_score" in score_html
+        assert "ゲーム別スコア" in score_html
+        assert "score_text" in score_html
         assert "ベンチ" in score_html
 
 
@@ -575,77 +549,107 @@ def test_winner_only_history_display_uses_winner_team_without_scores(monkeypatch
         assert "結果未入力" in html
 
 
-def test_score_mode_rejects_invalid_scores_without_changing_existing_values(monkeypatch, tmp_path):
+def test_score_mode_saves_game_score_text_and_calculated_result(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
     (tmp_path / "config.json").write_text(json.dumps({
         "score_input_mode": "score",
-        "scoring_system": {"points_per_game": 21, "games_per_match": 1},
-    }), encoding="utf-8")
-
-    with app_module.app.app_context():
-        match_id = add_history_match(app_module, 10, 8, 1)
-        client = app_module.app.test_client()
-
-        invalid_posts = [
-            {"team1_score": "-1", "team2_score": "8", "winner_team": "2"},
-            {"team1_score": "100000000000000000000000000000000000000000000000000", "team2_score": "8", "winner_team": "2"},
-            {"team1_score": "abc", "team2_score": "8", "winner_team": "2"},
-        ]
-        for data in invalid_posts:
-            response = client.post(f"/admin/match_history/{match_id}/score", data=data)
-            assert response.status_code == 302
-            match = app_module.db.session.get(app_module.MatchHistory, match_id)
-            assert (match.team1_score, match.team2_score, match.winner_team) == (10, 8, 1)
-
-
-def test_score_mode_accepts_scores_within_configured_range(monkeypatch, tmp_path):
-    app_module = load_history_test_app(monkeypatch, tmp_path)
-    (tmp_path / "config.json").write_text(json.dumps({
-        "score_input_mode": "score",
-        "scoring_system": {"points_per_game": 15, "games_per_match": 3},
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": True, "max_points": 30},
     }), encoding="utf-8")
 
     with app_module.app.app_context():
         match_id = add_history_match(app_module, None, None, None)
         response = app_module.app.test_client().post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "45", "team2_score": "44", "winner_team": "1",
+            "score_text": "21-15\n10-21\n22 - 20",
         })
 
         assert response.status_code == 302
         match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (45, 44, 1)
+        assert match.score_text == "21-15\n10-21\n22-20"
+        assert (match.team1_score, match.team2_score, match.winner_team) == (2, 1, 1)
 
 
-def test_score_mode_honors_posted_winner_selection(monkeypatch, tmp_path):
+def test_score_mode_allows_tied_game_count_and_blank_clear(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
-    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 2},
+    }), encoding="utf-8")
 
     with app_module.app.app_context():
-        match_id = add_history_match(app_module, 21, 15, 1)
+        match_id = add_history_match(app_module, None, None, None)
+        client = app_module.app.test_client()
+        client.post(f"/admin/match_history/{match_id}/score", data={"score_text": "21-15\n10-21"})
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.team1_score, match.team2_score, match.winner_team) == (1, 1, None)
+        assert match.score_text == "21-15\n10-21"
+
+        client.post(f"/admin/match_history/{match_id}/score", data={"score_text": ""})
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == (None, None, None, None)
+
+
+def test_score_mode_rejects_invalid_game_scores_without_changing_existing(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": False, "max_points": 21},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, 2, 1, 1)
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        match.score_text = "21-15\n10-21\n21-19"
+        app_module.db.session.commit()
         client = app_module.app.test_client()
 
-        response = client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "21", "team2_score": "15", "winner_team": "",
-        })
-        assert response.status_code == 302
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert (match.team1_score, match.team2_score, match.winner_team) == (21, 15, None)
+        for score_text in ("abc", "21", "21-", "-15", "21:15", "22-20", "20-19", "21-15\n21-15\n21-15\n21-15"):
+            response = client.post(f"/admin/match_history/{match_id}/score", data={"score_text": score_text})
+            assert response.status_code == 302
+            match = app_module.db.session.get(app_module.MatchHistory, match_id)
+            assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == ("21-15\n10-21\n21-19", 2, 1, 1)
 
-        client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "21", "team2_score": "15", "winner_team": "1",
-        })
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert match.winner_team == 1
 
-        client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "21", "team2_score": "15", "winner_team": "2",
-        })
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert match.winner_team == 2
+def test_deuce_rules_accept_and_reject_expected_scores(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    scoring = {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": True, "max_points": 30}
 
-        response = client.post(f"/admin/match_history/{match_id}/score", data={
-            "team1_score": "21", "team2_score": "15", "winner_team": "bad",
-        })
-        assert response.status_code == 302
-        match = app_module.db.session.get(app_module.MatchHistory, match_id)
-        assert match.winner_team is None
+    assert app_module.parse_score_text("22-20", scoring)[:4] == (True, "22-20", 1, 0)
+    assert app_module.parse_score_text("30-29", scoring)[:4] == (True, "30-29", 1, 0)
+    assert app_module.parse_score_text("21-20", scoring)[0] is False
+    assert app_module.parse_score_text("31-29", scoring)[0] is False
+
+
+def test_ensure_database_tables_adds_score_text_column_without_deleting_rows(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        app_module.db.session.execute(app_module.text("DROP TABLE match_histories"))
+        app_module.db.session.execute(app_module.text("""
+            CREATE TABLE match_histories (
+                id INTEGER PRIMARY KEY,
+                round_id INTEGER NOT NULL,
+                court_number INTEGER NOT NULL,
+                team1_player1_id INTEGER NOT NULL,
+                team1_player2_id INTEGER NOT NULL,
+                team2_player1_id INTEGER NOT NULL,
+                team2_player2_id INTEGER NOT NULL,
+                team1_score INTEGER,
+                team2_score INTEGER,
+                winner_team INTEGER,
+                created_at DATETIME NOT NULL
+            )
+        """))
+        app_module.db.session.execute(app_module.text("""
+            INSERT INTO match_histories (
+                id, round_id, court_number, team1_player1_id, team1_player2_id,
+                team2_player1_id, team2_player2_id, winner_team, created_at
+            ) VALUES (1, 1, 1, 1, 2, 3, 4, 1, '2026-06-28 00:00:00')
+        """))
+        app_module.db.session.commit()
+
+        app_module.ensure_database_tables()
+        columns = {column["name"] for column in app_module.inspect(app_module.db.engine).get_columns("match_histories")}
+        row_count = app_module.db.session.execute(app_module.text("SELECT COUNT(*) FROM match_histories")).scalar()
+
+        assert "score_text" in columns
+        assert row_count == 1

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -519,8 +519,113 @@ def test_match_history_input_ui_switches_by_score_mode(monkeypatch, tmp_path):
         (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "score"}), encoding="utf-8")
         score_html = client.get("/admin/match_history").get_data(as_text=True)
         assert "ゲーム別スコア" in score_html
-        assert "score_text" in score_html
+        assert "<textarea" not in score_html
+        assert 'name="game1_team1_score"' in score_html
+        assert 'name="game1_team2_score"' in score_html
         assert "ベンチ" in score_html
+
+
+def test_score_mode_dropdown_rows_follow_games_per_match(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_history_match(app_module, None, None, None)
+        client = app_module.app.test_client()
+
+        (tmp_path / "config.json").write_text(json.dumps({
+            "score_input_mode": "score",
+            "scoring_system": {"points_per_game": 21, "games_per_match": 1},
+        }), encoding="utf-8")
+        one_game_html = client.get("/admin/match_history").get_data(as_text=True)
+        assert 'name="game1_team1_score"' in one_game_html
+        assert 'name="game2_team1_score"' not in one_game_html
+
+        (tmp_path / "config.json").write_text(json.dumps({
+            "score_input_mode": "score",
+            "scoring_system": {"points_per_game": 21, "games_per_match": 3},
+        }), encoding="utf-8")
+        three_game_html = client.get("/admin/match_history").get_data(as_text=True)
+        assert 'name="game1_team1_score"' in three_game_html
+        assert 'name="game2_team1_score"' in three_game_html
+        assert 'name="game3_team1_score"' in three_game_html
+        assert 'name="game4_team1_score"' not in three_game_html
+
+
+def test_score_mode_dropdown_options_use_max_points_and_redisplay_saved_scores(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": True, "max_points": 30},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, 2, 1, 1)
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        match.score_text = "21-15\n10-21\n22-20"
+        app_module.db.session.commit()
+
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert '<option value=""' in html
+        assert '<option value="30"' in html
+        assert 'name="game1_team1_score"' in html
+        assert 'value="21" selected' in html
+        assert 'value="15" selected' in html
+        assert 'value="10" selected' in html
+        assert 'value="22" selected' in html
+        assert "21-15" in html
+        assert "10-21" in html
+        assert "22-20" in html
+
+
+def test_score_mode_saves_dropdown_scores_and_ignores_blank_rows(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": True, "max_points": 30},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, None, None, None)
+        response = app_module.app.test_client().post(f"/admin/match_history/{match_id}/score", data={
+            "game1_team1_score": "21",
+            "game1_team2_score": "15",
+            "game2_team1_score": "",
+            "game2_team2_score": "",
+            "game3_team1_score": "",
+            "game3_team2_score": "",
+        })
+
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == ("21-15", 1, 0, 1)
+
+
+def test_score_mode_rejects_partially_blank_dropdown_without_changing_existing(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        match_id = add_history_match(app_module, 1, 0, 1)
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        match.score_text = "21-15"
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post(f"/admin/match_history/{match_id}/score", data={
+            "game1_team1_score": "21",
+            "game1_team2_score": "",
+            "game2_team1_score": "",
+            "game2_team2_score": "15",
+            "game3_team1_score": "21",
+            "game3_team2_score": "15",
+        })
+
+        assert response.status_code == 302
+        match = app_module.db.session.get(app_module.MatchHistory, match_id)
+        assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == ("21-15", 1, 0, 1)
 
 
 def test_winner_only_history_display_uses_winner_team_without_scores(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Allow administrators to enter match results (winner-only or full scores) for confirmed match history entries and persist them in existing `MatchHistory` columns.
- Store the score-input mode and simple scoring-system settings in `config.json` with safe defaults and validation so older configs continue to work.
- Provide an admin UI to toggle modes and edit results from the history list without changing existing history storage formats or match-generation logic.

### Description
- Add config normalization and defaults for `score_input_mode` and `scoring_system` in `load_config()` and helpers (`normalize_score_input_mode`, `normalize_scoring_system`, etc.) to ensure backward compatibility and safe parsing. (app.py)
- Extend `/admin/settings` to persist `score_input_mode` and `scoring_system` (points per game / games per match) and add corresponding inputs to the settings template. (app.py, templates/admin_settings.html, config.example.json)
- Add a POST route `POST /admin/match_history/<match_history_id>/score` that updates `MatchHistory.team1_score`, `team2_score`, and `winner_team` according to the configured mode; includes robust parsing for blank/non-numeric input and handles invalid IDs gracefully. (app.py)
- Update the admin match history template to show an inline result-entry form that switches UI based on the configured mode (`winner_only` or `score`) and preserves existing display of participants, bench, and empty state. (templates/match_history.html)
- Add tests covering config defaults/validation, settings UI/save, winner-only updates, score-mode updates (including blank/invalid inputs), invalid IDs, and UI switching behavior. (tests/test_match_history.py)

### Testing
- Ran targeted tests with `pytest tests/test_match_history.py tests/test_flash_messages.py` and observed all tests in those files passed (`24 passed`).
- Ran the full test suite with `pytest` and confirmed all tests passed (`89 passed`).
- Manual rendering checks are covered by the new template tests which assert presence/absence of score fields based on `score_input_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd97f84088333b03999923a3d8738)