### PR TITLE
Add match history JSON dump, dump-and-clear actions, and automatic dump before full reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ config.json
 # 状態保存ファイル
 match_state.json
 draft_state.json
+# 生成された履歴ダンプ
+instance/history_dumps/

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 import io
 import logging
 import re
+from datetime import datetime, timezone
 from io import TextIOWrapper
 from flask import Flask, render_template, request, redirect, url_for, abort
 from models import db, Participant, MatchRound, MatchHistory, BenchHistory
@@ -822,6 +823,14 @@ def admin_settings():
 
 @app.route('/admin/reset_db', methods=['POST'])
 def reset_db():
+    try:
+        dump_match_history_to_json('clear_all_data')
+    except OSError:
+        db.session.rollback()
+        app.logger.exception('Failed to dump match history before clearing all data')
+        flash('試合履歴のJSON保存に失敗したため、全データ削除を中止しました')
+        return redirect(url_for('admin_settings'))
+
     # 先にマッチ状態をリセット
     reset_match_state()
     db.create_all()
@@ -833,6 +842,127 @@ def reset_db():
     db.session.commit()
     flash('参加者データと試合情報をすべて削除しました')
     return redirect(url_for('admin_settings'))
+
+
+def serialize_datetime(value):
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+def build_participant_dump_map(rounds):
+    participant_ids = set()
+    for match_round in rounds:
+        for match in match_round.matches:
+            participant_ids.update([
+                match.team1_player1_id,
+                match.team1_player2_id,
+                match.team2_player1_id,
+                match.team2_player2_id,
+            ])
+        for bench_history in match_round.bench_players:
+            participant_ids.add(bench_history.participant_id)
+
+    if not participant_ids:
+        return {}
+
+    participants = Participant.query.filter(Participant.id.in_(participant_ids)).all()
+    return {
+        participant.id: {
+            "name": participant.name,
+            "card": participant.card,
+        }
+        for participant in participants
+    }
+
+
+def participant_dump_fields(participant_map, participant_id, prefix=None):
+    participant = participant_map.get(participant_id, {})
+    data = {
+        "id": participant_id,
+        "name": participant.get("name", "不明な参加者"),
+        "card": participant.get("card"),
+    }
+    if prefix is None:
+        return {
+            "participant_id": data["id"],
+            "name": data["name"],
+            "card": data["card"],
+        }
+    return {
+        f"{prefix}_id": data["id"],
+        f"{prefix}_name": data["name"],
+        f"{prefix}_card": data["card"],
+    }
+
+
+def build_match_history_dump(reason):
+    rounds = (
+        MatchRound.query
+        .options(
+            selectinload(MatchRound.matches),
+            selectinload(MatchRound.bench_players),
+        )
+        .order_by(MatchRound.created_at.asc(), MatchRound.id.asc())
+        .all()
+    )
+    participant_map = build_participant_dump_map(rounds)
+
+    return {
+        "schema_version": 1,
+        "dumped_at": datetime.now(timezone.utc).isoformat(),
+        "reason": reason,
+        "rounds": [
+            {
+                "id": match_round.id,
+                "round_number": match_round.round_number,
+                "created_at": serialize_datetime(match_round.created_at),
+                "matches": [
+                    {
+                        "id": match.id,
+                        "court_number": match.court_number,
+                        **participant_dump_fields(participant_map, match.team1_player1_id, "team1_player1"),
+                        **participant_dump_fields(participant_map, match.team1_player2_id, "team1_player2"),
+                        **participant_dump_fields(participant_map, match.team2_player1_id, "team2_player1"),
+                        **participant_dump_fields(participant_map, match.team2_player2_id, "team2_player2"),
+                        "score_text": match.score_text,
+                        "team1_score": match.team1_score,
+                        "team2_score": match.team2_score,
+                        "winner_team": match.winner_team,
+                        "created_at": serialize_datetime(match.created_at),
+                    }
+                    for match in sorted(match_round.matches, key=lambda item: (item.court_number, item.id))
+                ],
+                "bench": [
+                    {
+                        **participant_dump_fields(participant_map, bench_history.participant_id),
+                        "created_at": serialize_datetime(bench_history.created_at),
+                    }
+                    for bench_history in sorted(match_round.bench_players, key=lambda item: item.id)
+                ],
+            }
+            for match_round in rounds
+        ],
+    }
+
+
+def dump_match_history_to_json(reason):
+    dump_dir = os.path.join(app.instance_path, 'history_dumps')
+    os.makedirs(dump_dir, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')
+    dump_path = os.path.join(dump_dir, f'match_history_{reason}_{timestamp}.json')
+    dump_data = build_match_history_dump(reason)
+    with open(dump_path, 'w', encoding='utf-8') as dump_file:
+        json.dump(dump_data, dump_file, indent=2, ensure_ascii=False)
+    return dump_path
+
+
+def clear_match_history_records():
+    BenchHistory.query.delete()
+    MatchHistory.query.delete()
+    MatchRound.query.delete()
 
 
 def format_participant_label(participant):
@@ -1050,6 +1180,43 @@ def update_match_result_score(match_history_id):
     db.session.commit()
     flash('試合結果を保存しました')
     return redirect(url_for('match_result', mode='admin'))
+
+
+@app.route('/admin/match_history/dump', methods=['POST'])
+def dump_match_history():
+    try:
+        dump_path = dump_match_history_to_json('manual_dump')
+    except OSError:
+        app.logger.exception('Failed to dump match history')
+        flash('試合履歴のJSON保存に失敗しました')
+        return redirect(url_for('admin_match_history'))
+
+    flash(f'試合履歴をJSONに保存しました: {os.path.basename(dump_path)}')
+    return redirect(url_for('admin_match_history'))
+
+
+@app.route('/admin/match_history/dump_and_clear', methods=['POST'])
+def dump_and_clear_match_history():
+    try:
+        dump_path = dump_match_history_to_json('manual_dump_and_clear')
+    except OSError:
+        db.session.rollback()
+        app.logger.exception('Failed to dump match history before clearing')
+        flash('試合履歴のJSON保存に失敗したため、履歴消去を中止しました')
+        return redirect(url_for('admin_match_history'))
+
+    try:
+        clear_match_history_records()
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        app.logger.exception('Failed to clear match history after dumping')
+        flash('試合履歴の消去に失敗しました。DB上の履歴は保持されています')
+        return redirect(url_for('admin_match_history'))
+
+    flash(f'試合履歴をJSONに保存してからDB上の履歴を消去しました: {os.path.basename(dump_path)}')
+    return redirect(url_for('admin_match_history'))
+
 
 @app.route('/admin/match_history')
 def admin_match_history():

--- a/app.py
+++ b/app.py
@@ -825,7 +825,7 @@ def admin_settings():
 def reset_db():
     try:
         dump_match_history_to_json('clear_all_data')
-    except OSError:
+    except Exception:
         db.session.rollback()
         app.logger.exception('Failed to dump match history before clearing all data')
         flash('試合履歴のJSON保存に失敗したため、全データ削除を中止しました')

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -70,6 +70,22 @@
             font-size: 18px;
         }
 
+        .history-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 16px 0;
+        }
+
+        .history-actions form {
+            margin: 0;
+        }
+
+        .history-actions button {
+            cursor: pointer;
+            padding: 8px 12px;
+        }
+
         @media (max-width: 600px) {
             body {
                 margin: 10px;
@@ -85,6 +101,14 @@
     {% include "_flash_messages.html" %}
     <h1>試合履歴</h1>
     <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a></p>
+    <div class="history-actions" aria-label="試合履歴操作">
+        <form method="post" action="{{ url_for('dump_match_history') }}">
+            <button type="submit">履歴をJSONにダンプ</button>
+        </form>
+        <form method="post" action="{{ url_for('dump_and_clear_match_history') }}">
+            <button type="submit" onclick="return confirm('履歴をJSONに保存してからDB上の履歴を消去します。よろしいですか？');">履歴をダンプして消去</button>
+        </form>
+    </div>
 
     {% if rounds %}
         {% for round in rounds %}

--- a/tests/test_flash_messages.py
+++ b/tests/test_flash_messages.py
@@ -79,6 +79,7 @@ def test_reset_db_flash_is_rendered_on_admin_settings(monkeypatch, tmp_path):
         "Participant",
         SimpleNamespace(query=SimpleNamespace(delete=lambda: 0)),
     )
+    monkeypatch.setattr(app_module, "dump_match_history_to_json", lambda reason: None)
     client = app_module.app.test_client()
 
     response = client.post("/admin/reset_db", follow_redirects=True)

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -985,3 +985,176 @@ def test_admin_match_result_invalid_score_keeps_existing_value(monkeypatch, tmp_
         assert response.status_code == 302
         match = app_module.db.session.get(app_module.MatchHistory, match_id)
         assert (match.score_text, match.team1_score, match.team2_score, match.winner_team) == ("21-15", 1, 0, 1)
+
+
+def add_dump_fixture(app_module, missing_participant=False):
+    participants = add_participants(app_module, 5)
+    participants[0].games_played = 7
+    round_record = app_module.MatchRound(round_number=3)
+    app_module.db.session.add(round_record)
+    app_module.db.session.flush()
+    app_module.db.session.add(app_module.MatchHistory(
+        round_id=round_record.id,
+        court_number=2,
+        team1_player1_id=participants[0].id,
+        team1_player2_id=participants[1].id,
+        team2_player1_id=participants[2].id,
+        team2_player2_id=9999 if missing_participant else participants[3].id,
+        score_text="21-15\n18-21\n21-19",
+        team1_score=2,
+        team2_score=1,
+        winner_team=1,
+    ))
+    app_module.db.session.add(app_module.BenchHistory(round_id=round_record.id, participant_id=participants[4].id))
+    app_module.db.session.commit()
+    return participants
+
+
+def read_latest_dump(app_module):
+    dump_dir = os.path.join(app_module.app.instance_path, "history_dumps")
+    dump_paths = [os.path.join(dump_dir, name) for name in os.listdir(dump_dir)]
+    assert dump_paths
+    latest_dump_path = max(dump_paths, key=os.path.getmtime)
+    with open(latest_dump_path, encoding="utf-8") as dump_file:
+        return json.load(dump_file), latest_dump_path
+
+
+def test_admin_match_history_dump_creates_structured_json_and_keeps_db(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        participants = add_dump_fixture(app_module)
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 1
+
+        data, dump_path = read_latest_dump(app_module)
+        assert os.path.basename(dump_path).startswith("match_history_manual_dump_")
+        assert data["schema_version"] == 1
+        assert data["dumped_at"]
+        assert data["reason"] == "manual_dump"
+        assert len(data["rounds"]) == 1
+        round_data = data["rounds"][0]
+        assert round_data["round_number"] == 3
+        assert round_data["created_at"]
+        match_data = round_data["matches"][0]
+        assert match_data["court_number"] == 2
+        assert match_data["team1_player1_name"] == participants[0].name
+        assert match_data["team1_player1_card"] == participants[0].card
+        assert match_data["score_text"] == "21-15\n18-21\n21-19"
+        assert match_data["team1_score"] == 2
+        assert match_data["team2_score"] == 1
+        assert match_data["winner_team"] == 1
+        assert round_data["bench"][0]["name"] == participants[4].name
+        assert round_data["bench"][0]["card"] == participants[4].card
+
+
+def test_admin_match_history_dump_handles_missing_participant(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_dump_fixture(app_module, missing_participant=True)
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+
+        assert response.status_code == 302
+        data, _ = read_latest_dump(app_module)
+        match_data = data["rounds"][0]["matches"][0]
+        assert match_data["team2_player2_id"] == 9999
+        assert match_data["team2_player2_name"] == "不明な参加者"
+        assert match_data["team2_player2_card"] is None
+
+
+def test_admin_match_history_dump_and_clear_dumps_then_clears_history_only(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        participants = add_dump_fixture(app_module)
+        participant_id = participants[0].id
+        response = app_module.app.test_client().post("/admin/match_history/dump_and_clear")
+
+        assert response.status_code == 302
+        data, dump_path = read_latest_dump(app_module)
+        assert os.path.basename(dump_path).startswith("match_history_manual_dump_and_clear_")
+        assert data["reason"] == "manual_dump_and_clear"
+        assert len(data["rounds"]) == 1
+        assert app_module.MatchRound.query.count() == 0
+        assert app_module.MatchHistory.query.count() == 0
+        assert app_module.BenchHistory.query.count() == 0
+        participant = app_module.db.session.get(app_module.Participant, participant_id)
+        assert participant is not None
+        assert participant.games_played == 7
+
+
+def test_admin_match_history_dump_and_clear_keeps_db_when_dump_fails(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_dump_fixture(app_module)
+        monkeypatch.setattr(app_module, "dump_match_history_to_json", lambda reason: (_ for _ in ()).throw(OSError("nope")))
+        response = app_module.app.test_client().post("/admin/match_history/dump_and_clear")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 1
+
+
+def test_reset_db_dumps_history_before_clearing_all_data(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        participants = add_dump_fixture(app_module)
+        expected_name = participants[0].name
+        expected_card = participants[0].card
+        response = app_module.app.test_client().post("/admin/reset_db")
+
+        assert response.status_code == 302
+        data, dump_path = read_latest_dump(app_module)
+        assert os.path.basename(dump_path).startswith("match_history_clear_all_data_")
+        assert data["reason"] == "clear_all_data"
+        assert data["rounds"][0]["matches"][0]["team1_player1_name"] == expected_name
+        assert data["rounds"][0]["matches"][0]["team1_player1_card"] == expected_card
+        assert app_module.Participant.query.count() == 0
+        assert app_module.MatchRound.query.count() == 0
+
+
+def test_reset_db_aborts_when_history_dump_fails(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_dump_fixture(app_module)
+        monkeypatch.setattr(app_module, "dump_match_history_to_json", lambda reason: (_ for _ in ()).throw(OSError("nope")))
+        response = app_module.app.test_client().post("/admin/reset_db")
+
+        assert response.status_code == 302
+        assert app_module.Participant.query.count() == 5
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 1
+
+
+def test_admin_match_history_dump_empty_history_writes_empty_rounds(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+
+        assert response.status_code == 302
+        data, _ = read_latest_dump(app_module)
+        assert data["reason"] == "manual_dump"
+        assert data["rounds"] == []
+
+
+def test_admin_match_history_page_displays_dump_buttons(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert "履歴をJSONにダンプ" in html
+        assert "履歴をダンプして消去" in html
+        assert "/admin/match_history/dump" in html
+        assert "/admin/match_history/dump_and_clear" in html

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import os
+from pathlib import Path
 import sys
 
 import pytest
@@ -42,6 +43,12 @@ def write_draft(tmp_path, matches, bench, court_count=None):
         draft["court_count"] = court_count
     (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
 
+
+def test_history_dump_directory_is_gitignored():
+    repo_root = Path(__file__).resolve().parents[1]
+    gitignore = (repo_root / ".gitignore").read_text(encoding="utf-8")
+
+    assert "instance/history_dumps/" in gitignore.splitlines()
 
 def test_confirm_match_persists_round_matches_bench_and_preserves_state_flow(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
@@ -1126,10 +1133,18 @@ def test_reset_db_aborts_when_history_dump_fails(monkeypatch, tmp_path):
 
     with app_module.app.app_context():
         add_dump_fixture(app_module)
-        monkeypatch.setattr(app_module, "dump_match_history_to_json", lambda reason: (_ for _ in ()).throw(OSError("nope")))
-        response = app_module.app.test_client().post("/admin/reset_db")
+        monkeypatch.setattr(
+            app_module,
+            "dump_match_history_to_json",
+            lambda reason: (_ for _ in ()).throw(RuntimeError("db read failed")),
+        )
+        response = app_module.app.test_client().post(
+            "/admin/reset_db", follow_redirects=True
+        )
 
-        assert response.status_code == 302
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert "試合履歴のJSON保存に失敗したため、全データ削除を中止しました" in html
         assert app_module.Participant.query.count() == 5
         assert app_module.MatchRound.query.count() == 1
         assert app_module.MatchHistory.query.count() == 1


### PR DESCRIPTION
### Motivation
- 保持すべき過去の試合履歴を削除する前に外部に保存して履歴を失わないようにするための機能追加です。 
- 管理者UIから手動で履歴をエクスポート／消去できるようにして運用の柔軟性を高めます。
- 将来の画面表示を想定して、ラウンド単位で参加者名・カード・スコア等を含む扱いやすいJSON構造でダンプします。

### Description
- `app.py` にダンプ用のシリアライザとビルダを追加し、`dump_match_history_to_json`, `build_match_history_dump`, `clear_match_history_records` などを実装して `MatchRound`/`MatchHistory`/`BenchHistory` を構造化して出力するようにしました。
- `/admin/match_history/dump` と `/admin/match_history/dump_and_clear` の2つの POST ルートを追加し、手動ダンプと「ダンプ成功後にDB履歴を削除」を安全に実行するようにしました。
- 管理者設定の全データ削除処理 (`/admin/reset_db`) を修正して、削除前に `clear_all_data` 理由で自動ダンプを行い、ダンプに失敗した場合は削除を中止するようにしました。
- テンプレート `templates/match_history.html` に「履歴をJSONにダンプ」「履歴をダンプして消去」ボタンと確認ダイアログを追加しました。
- ダンプは `instance/history_dumps/match_history_{reason}_{YYYYMMDD_HHMMSS_%f}.json` に保存し、参加者不明時のフォールバック（例: 名前を "不明な参加者"、card を null）や日時のISO表現、`schema_version`/`dumped_at`/`reason` を含む構造を採用しています。

### Testing
- `pytest tests/test_match_history.py` を実行し、追加されたケース（手動ダンプ、ダンプ後消去、安全性、空履歴、全データ削除前ダンプ、参加者不在ハンドリング、UIボタン表示）を含むテストが通過しました.
- リポジトリ全体の `pytest` を実行して問題がないことを確認し、テスト結果は `114 passed` でした.
- 変更したファイル: `app.py`, `templates/match_history.html`, `tests/test_match_history.py` (テスト追加・修正)。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40afc8141c8333a8bae00cf28a8952)