### PR TITLE
Save match results by round

### DIFF
--- a/app.py
+++ b/app.py
@@ -1115,6 +1115,16 @@ def parse_score_text(score_text, scoring_system):
     return True, "\n".join(effective_lines), team1_games, team2_games, winner_team
 
 
+def build_match_score_form(form, match_history_id):
+    """Return score fields for one match from a round-level score form."""
+    prefix = f"match_{match_history_id}_"
+    return {
+        key.removeprefix(prefix): value
+        for key, value in form.items()
+        if key.startswith(prefix)
+    }
+
+
 def apply_match_history_score_update(match_history, form):
     """Apply score form values to a MatchHistory row without committing."""
     config = load_config()
@@ -1142,6 +1152,67 @@ def apply_match_history_score_update(match_history, form):
         match_history.winner_team = parse_winner_team(form.get('winner_team'))
 
     return True, None
+
+
+def apply_round_score_updates(match_round):
+    """Apply all posted score updates for a MatchRound atomically."""
+    matches = sorted(match_round.matches, key=lambda match: match.court_number)
+    for match_history in matches:
+        updated, error_message = apply_match_history_score_update(
+            match_history,
+            build_match_score_form(request.form, match_history.id),
+        )
+        if not updated:
+            db.session.rollback()
+            return False, error_message
+    db.session.commit()
+    return True, None
+
+
+@app.route('/admin/match_history/round/<int:round_id>/score', methods=['POST'])
+def update_match_history_round_score(round_id):
+    match_round = (
+        MatchRound.query
+        .options(selectinload(MatchRound.matches))
+        .filter_by(id=round_id)
+        .first()
+    )
+    if match_round is None:
+        flash('指定された試合ラウンドが見つかりません')
+        return redirect(url_for('admin_match_history'))
+
+    updated, error_message = apply_round_score_updates(match_round)
+    if not updated:
+        flash(error_message)
+        return redirect(url_for('admin_match_history'))
+
+    flash('ラウンドの試合結果を保存しました')
+    return redirect(url_for('admin_match_history'))
+
+
+@app.route('/match/result/round/<int:round_id>/score', methods=['POST'])
+def update_match_result_round_score(round_id):
+    mode = request.form.get('mode', request.args.get('mode', 'admin'))
+    if mode != 'admin':
+        return redirect(url_for('match_result', mode='viewer'))
+
+    match_round = (
+        MatchRound.query
+        .options(selectinload(MatchRound.matches))
+        .filter_by(id=round_id)
+        .first()
+    )
+    if match_round is None:
+        flash('指定された試合ラウンドが見つかりません')
+        return redirect(url_for('match_result', mode='admin'))
+
+    updated, error_message = apply_round_score_updates(match_round)
+    if not updated:
+        flash(error_message)
+        return redirect(url_for('match_result', mode='admin'))
+
+    flash('ラウンドの試合結果を保存しました')
+    return redirect(url_for('match_result', mode='admin'))
 
 
 @app.route('/admin/match_history/<int:match_history_id>/score', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -1154,13 +1154,33 @@ def apply_match_history_score_update(match_history, form):
     return True, None
 
 
+def validate_round_winner_only_form(form):
+    """Validate winner_only round-level fields before applying any updates."""
+    winner_team = form.get("winner_team")
+    if winner_team in ("", "1", "2"):
+        return True, None
+    return False, "勝者の入力値が不正です"
+
+
 def apply_round_score_updates(match_round):
     """Apply all posted score updates for a MatchRound atomically."""
+    config = load_config()
     matches = sorted(match_round.matches, key=lambda match: match.court_number)
-    for match_history in matches:
+    match_forms = [
+        (match_history, build_match_score_form(request.form, match_history.id))
+        for match_history in matches
+    ]
+    if config["score_input_mode"] == "winner_only":
+        for _match_history, match_form in match_forms:
+            valid, error_message = validate_round_winner_only_form(match_form)
+            if not valid:
+                db.session.rollback()
+                return False, error_message
+
+    for match_history, match_form in match_forms:
         updated, error_message = apply_match_history_score_update(
             match_history,
-            build_match_score_form(request.form, match_history.id),
+            match_form,
         )
         if not updated:
             db.session.rollback()

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -48,6 +48,20 @@
             align-items: center;
         }
 
+        .round-score-form {
+            display: block;
+        }
+
+        .round-score-form .court-card {
+            display: block;
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        .round-score-form button[type="submit"] {
+            margin-top: 8px;
+        }
+
         .score-form input,
         .score-form select {
             width: 5em;

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -53,6 +53,10 @@
             width: 5em;
         }
 
+        .score-inputs {
+            margin-top: 8px;
+        }
+
         .score-row {
             display: flex;
             gap: 6px;
@@ -120,6 +124,7 @@
                     </time>
                 </h2>
 
+                <form method="post" action="{{ url_for('update_match_history_round_score', round_id=round.id) }}" class="score-form round-score-form">
                 {% for match in round.matches|sort(attribute='court_number') %}
                     <div class="court-card" data-match-history-id="{{ match.id }}">
                         <div class="court-title">{{ match.court_number }}コート</div>
@@ -158,20 +163,20 @@
                                 {% endif %}
                             {% endif %}
                         </div>
-                        <form method="post" action="{{ url_for('update_match_history_score', match_history_id=match.id) }}" class="score-form">
+                        <div class="score-inputs">
                             {% if score_input_mode == 'score' %}
                                 <div>ゲーム別スコア</div>
                                 <div>
                                     {% for score_row in score_rows_by_match_id.get(match.id, []) %}
                                         <div class="score-row">
-                                            <select name="game{{ loop.index }}_team1_score" aria-label="第{{ loop.index }}ゲーム team1 スコア">
+                                            <select name="match_{{ match.id }}_game{{ loop.index }}_team1_score" aria-label="{{ match.court_number }}コート 第{{ loop.index }}ゲーム team1 スコア">
                                                 <option value="" {% if score_row.team1 == '' %}selected{% endif %}></option>
                                                 {% for score_option in score_options %}
                                                     <option value="{{ score_option }}" {% if score_row.team1 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
                                                 {% endfor %}
                                             </select>
                                             <span>−</span>
-                                            <select name="game{{ loop.index }}_team2_score" aria-label="第{{ loop.index }}ゲーム team2 スコア">
+                                            <select name="match_{{ match.id }}_game{{ loop.index }}_team2_score" aria-label="{{ match.court_number }}コート 第{{ loop.index }}ゲーム team2 スコア">
                                                 <option value="" {% if score_row.team2 == '' %}selected{% endif %}></option>
                                                 {% for score_option in score_options %}
                                                     <option value="{{ score_option }}" {% if score_row.team2 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
@@ -182,17 +187,18 @@
                                 </div>
                             {% else %}
                                 <label>winner_team
-                                    <select name="winner_team">
+                                    <select name="match_{{ match.id }}_winner_team">
                                         <option value="" {% if match.winner_team is none %}selected{% endif %}>未入力</option>
                                         <option value="1" {% if match.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
                                         <option value="2" {% if match.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
                                     </select>
                                 </label>
                             {% endif %}
-                            <button type="submit">結果を保存</button>
-                        </form>
+                        </div>
                     </div>
                 {% endfor %}
+                    <button type="submit">このラウンドの結果を保存</button>
+                </form>
 
                 <div class="bench-section">
                     <strong>ベンチ</strong>

--- a/templates/match_result.html
+++ b/templates/match_result.html
@@ -70,6 +70,10 @@
         }
 
         .score-form {
+            margin-top: 10px;
+        }
+
+        .score-inputs {
             border-top: 1px solid #ddd;
             display: flex;
             flex-direction: column;
@@ -125,6 +129,11 @@
 
     <div style="display: flex; flex-wrap: wrap; gap: 20px;">
         <div class="court-scroll-container">
+            {% set result_round_id = (match_histories_by_court.values()|list|first).round_id if match_histories_by_court else none %}
+            {% if mode == 'admin' and not is_draft and result_round_id %}
+                <form method="post" action="{{ url_for('update_match_result_round_score', round_id=result_round_id) }}" class="score-form">
+                    <input type="hidden" name="mode" value="admin">
+            {% endif %}
             <div class="court-list">
                 {% for match in matches %}
                     {% set court_number = loop.index %}
@@ -182,21 +191,20 @@
                                         {% endif %}
                                     {% endif %}
                                 </div>
-                                <form method="post" action="{{ url_for('update_match_result_score', match_history_id=match_history.id) }}" class="score-form">
-                                    <input type="hidden" name="mode" value="admin">
+                                <div class="score-inputs">
                                     {% if score_input_mode == 'score' %}
                                         <div>ゲーム別スコア</div>
                                         <div>
                                             {% for score_row in score_rows_by_match_id.get(match_history.id, []) %}
                                                 <div class="score-row">
-                                                    <select name="game{{ loop.index }}_team1_score" aria-label="第{{ loop.index }}ゲーム team1 スコア">
+                                                    <select name="match_{{ match_history.id }}_game{{ loop.index }}_team1_score" aria-label="コート {{ court_number }} 第{{ loop.index }}ゲーム team1 スコア">
                                                         <option value="" {% if score_row.team1 == '' %}selected{% endif %}></option>
                                                         {% for score_option in score_options %}
                                                             <option value="{{ score_option }}" {% if score_row.team1 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
                                                         {% endfor %}
                                                     </select>
                                                     <span>−</span>
-                                                    <select name="game{{ loop.index }}_team2_score" aria-label="第{{ loop.index }}ゲーム team2 スコア">
+                                                    <select name="match_{{ match_history.id }}_game{{ loop.index }}_team2_score" aria-label="コート {{ court_number }} 第{{ loop.index }}ゲーム team2 スコア">
                                                         <option value="" {% if score_row.team2 == '' %}selected{% endif %}></option>
                                                         {% for score_option in score_options %}
                                                             <option value="{{ score_option }}" {% if score_row.team2 == score_option|string %}selected{% endif %}>{{ score_option }}</option>
@@ -207,15 +215,14 @@
                                         </div>
                                     {% else %}
                                         <label>winner_team
-                                            <select name="winner_team">
+                                            <select name="match_{{ match_history.id }}_winner_team">
                                                 <option value="" {% if match_history.winner_team is none %}selected{% endif %}>未入力</option>
                                                 <option value="1" {% if match_history.winner_team == 1 %}selected{% endif %}>team1 勝利</option>
                                                 <option value="2" {% if match_history.winner_team == 2 %}selected{% endif %}>team2 勝利</option>
                                             </select>
                                         </label>
                                     {% endif %}
-                                    <button type="submit">結果を保存</button>
-                                </form>
+                                </div>
                             {% else %}
                                 <div class="score-status">対応する試合履歴が見つかりません</div>
                             {% endif %}
@@ -223,6 +230,10 @@
                     </div>
                 {% endfor %}
             </div>
+            {% if mode == 'admin' and not is_draft and result_round_id %}
+                <button type="submit">このラウンドの結果を保存</button>
+                </form>
+            {% endif %}
         </div>
     </div>
 

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -527,8 +527,8 @@ def test_match_history_input_ui_switches_by_score_mode(monkeypatch, tmp_path):
         score_html = client.get("/admin/match_history").get_data(as_text=True)
         assert "ゲーム別スコア" in score_html
         assert "<textarea" not in score_html
-        assert 'name="game1_team1_score"' in score_html
-        assert 'name="game1_team2_score"' in score_html
+        assert 'name="match_' in score_html
+        assert 'name="match_' in score_html
         assert "ベンチ" in score_html
 
 
@@ -544,18 +544,18 @@ def test_score_mode_dropdown_rows_follow_games_per_match(monkeypatch, tmp_path):
             "scoring_system": {"points_per_game": 21, "games_per_match": 1},
         }), encoding="utf-8")
         one_game_html = client.get("/admin/match_history").get_data(as_text=True)
-        assert 'name="game1_team1_score"' in one_game_html
-        assert 'name="game2_team1_score"' not in one_game_html
+        assert 'name="match_' in one_game_html
+        assert '_game2_team1_score"' not in one_game_html
 
         (tmp_path / "config.json").write_text(json.dumps({
             "score_input_mode": "score",
             "scoring_system": {"points_per_game": 21, "games_per_match": 3},
         }), encoding="utf-8")
         three_game_html = client.get("/admin/match_history").get_data(as_text=True)
-        assert 'name="game1_team1_score"' in three_game_html
-        assert 'name="game2_team1_score"' in three_game_html
-        assert 'name="game3_team1_score"' in three_game_html
-        assert 'name="game4_team1_score"' not in three_game_html
+        assert 'name="match_' in three_game_html
+        assert '_game2_team1_score"' in three_game_html
+        assert '_game3_team1_score"' in three_game_html
+        assert '_game4_team1_score"' not in three_game_html
 
 
 def test_score_mode_dropdown_options_use_max_points_and_redisplay_saved_scores(monkeypatch, tmp_path):
@@ -575,7 +575,7 @@ def test_score_mode_dropdown_options_use_max_points_and_redisplay_saved_scores(m
 
         assert '<option value=""' in html
         assert '<option value="30"' in html
-        assert 'name="game1_team1_score"' in html
+        assert 'name="match_' in html
         assert 'value="21" selected' in html
         assert 'value="15" selected' in html
         assert 'value="10" selected' in html
@@ -950,7 +950,7 @@ def test_admin_match_result_score_dropdown_saves_and_redisplays(monkeypatch, tmp
         html = client.get("/match/result?mode=admin").get_data(as_text=True)
         assert "ゲームカウント: 2 - 1" in html
         assert "21-15" in html
-        assert 'name="game1_team1_score"' in html
+        assert 'name="match_' in html
         assert 'value="22" selected' in html
 
 
@@ -1173,3 +1173,102 @@ def test_admin_match_history_page_displays_dump_buttons(monkeypatch, tmp_path):
         assert "履歴をダンプして消去" in html
         assert "/admin/match_history/dump" in html
         assert "/admin/match_history/dump_and_clear" in html
+
+
+def add_history_round_with_two_matches(app_module):
+    add_participants(app_module, 8)
+    round_record = app_module.MatchRound(round_number=1)
+    app_module.db.session.add(round_record)
+    app_module.db.session.flush()
+    matches = []
+    for court_number, offset in ((1, 0), (2, 4)):
+        match = app_module.MatchHistory(
+            round_id=round_record.id,
+            court_number=court_number,
+            team1_player1_id=offset + 1,
+            team1_player2_id=offset + 2,
+            team2_player1_id=offset + 3,
+            team2_player2_id=offset + 4,
+            score_text="21-15",
+            team1_score=1,
+            team2_score=0,
+            winner_team=1,
+        )
+        app_module.db.session.add(match)
+        matches.append(match)
+    app_module.db.session.commit()
+    return round_record.id, [match.id for match in matches]
+
+
+def test_admin_match_history_round_score_saves_all_courts_atomically(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3, "deuce_enabled": True, "max_points": 30},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        response = app_module.app.test_client().post(f"/admin/match_history/round/{round_id}/score", data={
+            f"match_{match_ids[0]}_game1_team1_score": "10",
+            f"match_{match_ids[0]}_game1_team2_score": "21",
+            f"match_{match_ids[1]}_game1_team1_score": "22",
+            f"match_{match_ids[1]}_game1_team2_score": "20",
+        })
+
+        assert response.status_code == 302
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert (first.score_text, first.team1_score, first.team2_score, first.winner_team) == ("10-21", 0, 1, 2)
+        assert (second.score_text, second.team1_score, second.team2_score, second.winner_team) == ("22-20", 1, 0, 1)
+
+
+def test_admin_match_history_round_score_rolls_back_all_courts_on_invalid_input(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "score_input_mode": "score",
+        "scoring_system": {"points_per_game": 21, "games_per_match": 3},
+    }), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        response = app_module.app.test_client().post(f"/admin/match_history/round/{round_id}/score", data={
+            f"match_{match_ids[0]}_game1_team1_score": "10",
+            f"match_{match_ids[0]}_game1_team2_score": "21",
+            f"match_{match_ids[1]}_game1_team1_score": "22",
+            f"match_{match_ids[1]}_game1_team2_score": "",
+        })
+
+        assert response.status_code == 302
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert (first.score_text, first.team1_score, first.team2_score, first.winner_team) == ("21-15", 1, 0, 1)
+        assert (second.score_text, second.team1_score, second.team2_score, second.winner_team) == ("21-15", 1, 0, 1)
+
+
+def test_admin_match_result_round_score_saves_all_latest_courts(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        (tmp_path / "match_state.json").write_text(json.dumps({
+            "match_active": True,
+            "match_count": 1,
+            "matches": [[1, 2, 3, 4], [5, 6, 7, 8]],
+            "bench": [],
+            "court_count": 2,
+        }), encoding="utf-8")
+
+        response = app_module.app.test_client().post(f"/match/result/round/{round_id}/score", data={
+            "mode": "admin",
+            f"match_{match_ids[0]}_winner_team": "2",
+            f"match_{match_ids[1]}_winner_team": "",
+        })
+
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/match/result?mode=admin")
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert first.winner_team == 2
+        assert second.winner_team is None

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1272,3 +1272,90 @@ def test_admin_match_result_round_score_saves_all_latest_courts(monkeypatch, tmp
         second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
         assert first.winner_team == 2
         assert second.winner_team is None
+
+
+def test_admin_match_history_round_winner_only_rejects_invalid_winner_without_partial_save(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        first_before = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second_before = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        first_before.score_text = "19-21"
+        first_before.team1_score = 0
+        first_before.team2_score = 1
+        first_before.winner_team = 2
+        second_before.score_text = "21-17"
+        second_before.team1_score = 1
+        second_before.team2_score = 0
+        second_before.winner_team = 1
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post(f"/admin/match_history/round/{round_id}/score", data={
+            f"match_{match_ids[0]}_winner_team": "3",
+            f"match_{match_ids[1]}_winner_team": "2",
+        })
+
+        assert response.status_code == 302
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert (first.score_text, first.team1_score, first.team2_score, first.winner_team) == ("19-21", 0, 1, 2)
+        assert (second.score_text, second.team1_score, second.team2_score, second.winner_team) == ("21-17", 1, 0, 1)
+
+
+def test_admin_match_history_round_winner_only_allows_blank_and_valid_winners(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        response = app_module.app.test_client().post(f"/admin/match_history/round/{round_id}/score", data={
+            f"match_{match_ids[0]}_winner_team": "",
+            f"match_{match_ids[1]}_winner_team": "2",
+        })
+
+        assert response.status_code == 302
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert first.winner_team is None
+        assert second.winner_team == 2
+
+
+def test_admin_match_result_round_winner_only_rejects_invalid_winner_without_partial_save(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({"score_input_mode": "winner_only"}), encoding="utf-8")
+
+    with app_module.app.app_context():
+        round_id, match_ids = add_history_round_with_two_matches(app_module)
+        (tmp_path / "match_state.json").write_text(json.dumps({
+            "match_active": True,
+            "match_count": 1,
+            "matches": [[1, 2, 3, 4], [5, 6, 7, 8]],
+            "bench": [],
+            "court_count": 2,
+        }), encoding="utf-8")
+        first_before = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second_before = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        first_before.score_text = "19-21"
+        first_before.team1_score = 0
+        first_before.team2_score = 1
+        first_before.winner_team = 2
+        second_before.score_text = "21-17"
+        second_before.team1_score = 1
+        second_before.team2_score = 0
+        second_before.winner_team = 1
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post(f"/match/result/round/{round_id}/score", data={
+            "mode": "admin",
+            f"match_{match_ids[0]}_winner_team": "0",
+            f"match_{match_ids[1]}_winner_team": "2",
+        })
+
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/match/result?mode=admin")
+        first = app_module.db.session.get(app_module.MatchHistory, match_ids[0])
+        second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
+        assert (first.score_text, first.team1_score, first.team2_score, first.winner_team) == ("19-21", 0, 1, 2)
+        assert (second.score_text, second.team1_score, second.team2_score, second.winner_team) == ("21-17", 1, 0, 1)

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -303,6 +303,37 @@ def test_admin_match_history_page_displays_round_matches_bench_and_scores(monkey
         assert "勝者: team1" in html
 
 
+def test_admin_match_history_round_form_stacks_courts_before_single_save_button(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 8)
+        round_record = app_module.MatchRound(round_number=1)
+        app_module.db.session.add(round_record)
+        app_module.db.session.flush()
+        for court_number, offset in ((1, 0), (2, 4)):
+            app_module.db.session.add(app_module.MatchHistory(
+                round_id=round_record.id,
+                court_number=court_number,
+                team1_player1_id=offset + 1,
+                team1_player2_id=offset + 2,
+                team2_player1_id=offset + 3,
+                team2_player2_id=offset + 4,
+            ))
+        app_module.db.session.add(app_module.BenchHistory(round_id=round_record.id, participant_id=1))
+        app_module.db.session.commit()
+
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert 'class="score-form round-score-form"' in html
+        assert html.count("このラウンドの結果を保存") == 1
+        first_court_index = html.index("1コート")
+        second_court_index = html.index("2コート")
+        save_button_index = html.index("このラウンドの結果を保存")
+        bench_index = html.index("<strong>ベンチ</strong>")
+        assert first_court_index < second_court_index < save_button_index < bench_index
+
+
 def test_admin_match_history_page_formats_special_and_missing_participant_cards(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
 


### PR DESCRIPTION
### Motivation

- Reduce admin effort by allowing all courts in a `MatchRound` to be saved with a single action instead of one button per court.
- Ensure the existing `winner_only` / `score` input modes, score parsing, and validation logic are reused without changing semantics.
- Make the operation atomic so that if any court input is invalid the entire round is not committed.

### Description

- Added `build_match_score_form` to extract per-match prefixed fields from a round-level POST payload and `apply_round_score_updates` to validate and apply all courts atomically in `app.py`.
- Added new endpoints `POST /admin/match_history/round/<int:round_id>/score` and `POST /match/result/round/<int:round_id>/score` which reuse existing `apply_match_history_score_update` logic and flash on error or success.
- Updated `templates/match_history.html` and `templates/match_result.html` to render a single form per `MatchRound` (admin mode) and to prefix per-court input names as `match_<id>_...`, preserving viewer/draft behavior and existing score UI.
- Updated and added tests in `tests/test_match_history.py` to cover atomic multi-court saves, rollback on invalid input, and admin match-result round saves; also adjusted existing tests to the new prefixed input names.

### Testing

- Ran the full test suite with `pytest` after changes; all tests passed (`118 passed`).
- Added focused regression tests exercising multi-court round save success and rollback which passed under the same run.
- Verified templates render admin-only round form and viewer mode remains read-only via the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40bdda6d548333bf83310114232598)