### PR TITLE
Add match-history win rates to player scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from itertools import zip_longest
 from utils.match_state import load_match_state, save_match_state_full
 from utils.draft_state import clear_draft_state, get_active_draft, save_draft_state
 from utils.score import calculate_pair_score
+from utils.stats import calculate_participant_win_stats
 from utils.reset import reset_match_state
 from routes.api import api_bp
 
@@ -481,11 +482,13 @@ def edit_matches():
     level_map = config["level_map"]
     gender_weight = config["gender_weight"]
 
+    win_stats = calculate_participant_win_stats()
+
     # 各コート内を2人ずつペアにしてスコアをつける
     match_data = []  # 画面表示用
     for group in matches:  # group = [p1, p2, p3, p4]
         pairs = [group[i:i+2] for i in range(0, len(group), 2)]
-        scored_pairs = [calculate_pair_score(pair, level_map, gender_weight) for pair in pairs]
+        scored_pairs = [calculate_pair_score(pair, level_map, gender_weight, win_stats) for pair in pairs]
         match_data.append(scored_pairs)
 
     return render_template(

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,178 @@
+import importlib
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+from utils.score import calculate_pair_score
+
+
+def load_stats_test_app(monkeypatch, tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"level_map": {}, "gender_weight": {}}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    os.makedirs(app_module.app.instance_path, exist_ok=True)
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.app_context():
+        app_module.db.drop_all()
+        app_module.db.create_all()
+    return app_module
+
+
+def add_participants(app_module, count):
+    participants = []
+    for player_id in range(1, count + 1):
+        participant = app_module.Participant(
+            name=f"player-{player_id}",
+            gender="male",
+            level="beginner",
+            weight=1.0,
+            card=f"C{player_id}",
+        )
+        participants.append(participant)
+        app_module.db.session.add(participant)
+    app_module.db.session.commit()
+    return participants
+
+
+def add_round(app_module, round_number=1):
+    match_round = app_module.MatchRound(round_number=round_number)
+    app_module.db.session.add(match_round)
+    app_module.db.session.commit()
+    return match_round
+
+
+def add_history(app_module, match_round, player_ids, winner_team):
+    history = app_module.MatchHistory(
+        round_id=match_round.id,
+        court_number=1,
+        team1_player1_id=player_ids[0],
+        team1_player2_id=player_ids[1],
+        team2_player1_id=player_ids[2],
+        team2_player2_id=player_ids[3],
+        winner_team=winner_team,
+    )
+    app_module.db.session.add(history)
+    app_module.db.session.commit()
+    return history
+
+
+def test_winner_team_1_adds_wins_to_team1_and_losses_to_team2(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 4)
+        match_round = add_round(app_module)
+        add_history(app_module, match_round, [player.id for player in players], winner_team=1)
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert stats[players[0].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+        assert stats[players[1].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+        assert stats[players[2].id] == {"wins": 0, "losses": 1, "games": 1, "win_rate": 0.0}
+        assert stats[players[3].id] == {"wins": 0, "losses": 1, "games": 1, "win_rate": 0.0}
+
+
+def test_winner_team_2_adds_wins_to_team2_and_losses_to_team1(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 4)
+        match_round = add_round(app_module)
+        add_history(app_module, match_round, [player.id for player in players], winner_team=2)
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert stats[players[0].id] == {"wins": 0, "losses": 1, "games": 1, "win_rate": 0.0}
+        assert stats[players[1].id] == {"wins": 0, "losses": 1, "games": 1, "win_rate": 0.0}
+        assert stats[players[2].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+        assert stats[players[3].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+
+
+def test_unentered_winner_team_is_excluded_from_win_stats(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 4)
+        match_round = add_round(app_module)
+        add_history(app_module, match_round, [player.id for player in players], winner_team=None)
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert all(stats[player.id] == {"wins": 0, "losses": 0, "games": 0, "win_rate": 0.0} for player in players)
+
+
+def test_multiple_matches_aggregate_participant_win_stats(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 6)
+        first_round = add_round(app_module, 1)
+        second_round = add_round(app_module, 2)
+        add_history(app_module, first_round, [1, 2, 3, 4], winner_team=1)
+        add_history(app_module, second_round, [1, 3, 5, 6], winner_team=2)
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert stats[players[0].id] == {"wins": 1, "losses": 1, "games": 2, "win_rate": 0.5}
+        assert stats[players[1].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+        assert stats[players[2].id] == {"wins": 0, "losses": 2, "games": 2, "win_rate": 0.0}
+        assert stats[players[4].id] == {"wins": 1, "losses": 0, "games": 1, "win_rate": 1.0}
+
+
+def test_participant_without_match_history_has_zero_win_rate(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 5)
+        match_round = add_round(app_module)
+        add_history(app_module, match_round, [1, 2, 3, 4], winner_team=1)
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert stats[players[4].id] == {"wins": 0, "losses": 0, "games": 0, "win_rate": 0.0}
+
+
+def test_pair_score_matches_existing_calculation_without_win_history():
+    pair = [
+        SimpleNamespace(id=1, name="Alice", level="beginner", gender="female"),
+        SimpleNamespace(id=2, name="Bob", level="advanced", gender="male"),
+    ]
+
+    result = calculate_pair_score(
+        pair,
+        {"beginner": 1, "advanced": 3},
+        {"female": 0.9, "male": 1.0},
+        win_stats={},
+    )
+
+    assert result == {
+        "players": [
+            {"name": "Alice", "score": 0.9},
+            {"name": "Bob", "score": 3.0},
+        ],
+        "total_score": 3.9,
+    }
+
+
+def test_pair_score_adds_win_rate_to_level_weight_score():
+    pair = [SimpleNamespace(id=1, name="Alice", level="intermediate", gender="female")]
+
+    result = calculate_pair_score(
+        pair,
+        {"intermediate": 2},
+        {"female": 0.8},
+        win_stats={1: {"wins": 3, "losses": 2, "games": 5, "win_rate": 0.6}},
+    )
+
+    assert result == {"players": [{"name": "Alice", "score": 2.2}], "total_score": 2.2}
+
+
+def test_cleared_match_history_resets_win_rate_to_zero(monkeypatch, tmp_path):
+    app_module = load_stats_test_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        players = add_participants(app_module, 4)
+        match_round = add_round(app_module)
+        add_history(app_module, match_round, [player.id for player in players], winner_team=1)
+        app_module.MatchHistory.query.delete()
+        app_module.db.session.commit()
+
+        stats = app_module.calculate_participant_win_stats()
+
+        assert all(stats[player.id]["win_rate"] == 0.0 for player in players)

--- a/utils/score.py
+++ b/utils/score.py
@@ -1,10 +1,19 @@
-def calculate_pair_score(pair, level_map, gender_weight):
+from flask import has_app_context
+
+from utils.stats import calculate_participant_win_stats
+
+
+def calculate_pair_score(pair, level_map, gender_weight, win_stats=None):
+    if win_stats is None:
+        win_stats = calculate_participant_win_stats() if has_app_context() else {}
     players_info = []
     total_score = 0
     for player in pair:
         level = getattr(player, "level", None)
         gender = getattr(player, "gender", None)
-        score = round(level_map.get(level, 0) * gender_weight.get(gender, 1.0), 1)
+        participant_id = getattr(player, "id", None)
+        win_rate = win_stats.get(participant_id, {}).get("win_rate", 0.0)
+        score = round(level_map.get(level, 0) * gender_weight.get(gender, 1.0) + win_rate, 1)
         players_info.append({
             "name": player.name,
             "score": score

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -1,0 +1,42 @@
+from models import MatchHistory, Participant
+
+
+def _empty_stats():
+    return {"wins": 0, "losses": 0, "games": 0, "win_rate": 0.0}
+
+
+def calculate_participant_win_stats():
+    """Calculate per-participant win/loss stats from recorded match results.
+
+    Only MatchHistory rows with winner_team 1 or 2 are counted. Ties and
+    unentered results (winner_team is None) are ignored, and the values are not
+    persisted to the database.
+    """
+    stats = {participant.id: _empty_stats() for participant in Participant.query.all()}
+
+    histories = MatchHistory.query.filter(MatchHistory.winner_team.in_((1, 2))).all()
+    for history in histories:
+        team1_player_ids = [history.team1_player1_id, history.team1_player2_id]
+        team2_player_ids = [history.team2_player1_id, history.team2_player2_id]
+
+        if history.winner_team == 1:
+            winning_player_ids = team1_player_ids
+            losing_player_ids = team2_player_ids
+        else:
+            winning_player_ids = team2_player_ids
+            losing_player_ids = team1_player_ids
+
+        for participant_id in winning_player_ids:
+            participant_stats = stats.setdefault(participant_id, _empty_stats())
+            participant_stats["wins"] += 1
+
+        for participant_id in losing_player_ids:
+            participant_stats = stats.setdefault(participant_id, _empty_stats())
+            participant_stats["losses"] += 1
+
+    for participant_stats in stats.values():
+        games = participant_stats["wins"] + participant_stats["losses"]
+        participant_stats["games"] = games
+        participant_stats["win_rate"] = participant_stats["wins"] / games if games else 0.0
+
+    return stats


### PR DESCRIPTION
### Motivation

- Aggregate recorded match results (`MatchHistory.winner_team`) into per-participant win statistics so historical outcomes affect pairing scores. 
- Apply the computed `win_rate` to existing player scoring without changing persistent schema or stored participant fields. 
- Preserve existing behavior when there is no win history and exclude matches with `winner_team is None` from aggregation.

### Description

- Add `utils/stats.py` with `calculate_participant_win_stats()` which scans current-DB `MatchHistory` rows (only `winner_team` 1 or 2) and returns a map of `{participant_id: {"wins","losses","games","win_rate"}}`.
- Update `utils/score.py` to accept an optional `win_stats` and include `win_rate` in player score with the formula `level_score * weight + win_rate`, defaulting to `0.0` when no history exists or outside an app context.
- Compute `win_stats` once in `app.py` when preparing match edit view and pass it into `calculate_pair_score()` to avoid repeated aggregation during rendering.
- Add `tests/test_stats.py` covering winner-team handling, exclusion of `winner_team is None`, multi-match aggregation, participants with no history, scoring compatibility when `win_stats={}`, win-rate addition, and cleared-history behavior.

### Testing

- Ran `pytest tests/test_score.py tests/test_stats.py` and the targeted tests completed successfully.
- Ran the full test suite with `pytest` and all tests passed (`130 passed`).
- New tests are included in `tests/test_stats.py` and were executed as part of the above runs.
- No database schema changes or participant model fields were added or persisted as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40cf2ced2c8333975911ff72b9bab1)