### PR TITLE
Add match history archive view

### DIFF
--- a/app.py
+++ b/app.py
@@ -960,6 +960,85 @@ def get_match_history_dump_dir():
     return os.path.join(app.instance_path, 'history_dumps')
 
 
+def get_match_history_archive_path(filename):
+    if not HISTORY_DUMP_FILENAME_RE.fullmatch(filename or ""):
+        abort(404)
+
+    dump_dir = os.path.realpath(get_match_history_dump_dir())
+    archive_path = os.path.realpath(os.path.join(dump_dir, filename))
+    if os.path.dirname(archive_path) != dump_dir or not os.path.isfile(archive_path):
+        abort(404)
+    return archive_path
+
+
+def normalize_match_history_archive(data):
+    if not isinstance(data, dict):
+        data = {}
+
+    normalized_rounds = []
+    rounds = data.get("rounds")
+    if not isinstance(rounds, list):
+        rounds = []
+
+    for round_data in rounds:
+        if not isinstance(round_data, dict):
+            continue
+
+        matches = round_data.get("matches")
+        if not isinstance(matches, list):
+            matches = []
+
+        bench = round_data.get("bench")
+        if not isinstance(bench, list):
+            bench = []
+
+        normalized_rounds.append({
+            "round_number": round_data.get("round_number"),
+            "created_at": round_data.get("created_at"),
+            "matches": [match for match in matches if isinstance(match, dict)],
+            "bench": [bench_item for bench_item in bench if isinstance(bench_item, dict)],
+        })
+
+    return {
+        "schema_version": data.get("schema_version"),
+        "dumped_at": data.get("dumped_at"),
+        "reason": data.get("reason"),
+        "rounds": normalized_rounds,
+    }
+
+
+def build_match_history_archive_metadata(filename, path):
+    stat_result = os.stat(path)
+    metadata = {
+        "filename": filename,
+        "size": stat_result.st_size,
+        "modified_at": datetime.fromtimestamp(stat_result.st_mtime, timezone.utc),
+        "dumped_at": None,
+        "reason": None,
+        "round_count": 0,
+        "match_count": 0,
+        "bench_count": 0,
+        "status": "ok",
+        "error_message": None,
+    }
+
+    try:
+        with open(path, encoding='utf-8') as archive_file:
+            archive = normalize_match_history_archive(json.load(archive_file))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        app.logger.exception('Failed to read match history archive JSON: %s', filename)
+        metadata["status"] = "error"
+        metadata["error_message"] = "読み込みエラー"
+        return metadata
+
+    metadata["dumped_at"] = archive["dumped_at"]
+    metadata["reason"] = archive["reason"]
+    metadata["round_count"] = len(archive["rounds"])
+    metadata["match_count"] = sum(len(round_data["matches"]) for round_data in archive["rounds"])
+    metadata["bench_count"] = sum(len(round_data["bench"]) for round_data in archive["rounds"])
+    return metadata
+
+
 def list_match_history_archives():
     dump_dir = get_match_history_dump_dir()
     if not os.path.isdir(dump_dir):
@@ -967,30 +1046,25 @@ def list_match_history_archives():
 
     archives = []
     for filename in os.listdir(dump_dir):
-        if not HISTORY_DUMP_FILENAME_RE.match(filename):
+        if not HISTORY_DUMP_FILENAME_RE.fullmatch(filename):
             continue
-        path = os.path.join(dump_dir, filename)
-        if not os.path.isfile(path):
+        try:
+            path = get_match_history_archive_path(filename)
+        except Exception:
             continue
-        stat_result = os.stat(path)
-        archives.append({
-            "filename": filename,
-            "size": stat_result.st_size,
-            "modified_at": datetime.fromtimestamp(stat_result.st_mtime, timezone.utc),
-        })
-    return sorted(archives, key=lambda archive: archive["modified_at"], reverse=True)
+        archives.append(build_match_history_archive_metadata(filename, path))
+
+    return sorted(
+        archives,
+        key=lambda archive: (archive["dumped_at"] or archive["modified_at"].isoformat()),
+        reverse=True,
+    )
 
 
 def load_match_history_archive(filename):
-    if not HISTORY_DUMP_FILENAME_RE.match(filename):
-        abort(404)
-
-    archive_path = os.path.join(get_match_history_dump_dir(), filename)
-    if not os.path.isfile(archive_path):
-        abort(404)
-
+    archive_path = get_match_history_archive_path(filename)
     with open(archive_path, encoding='utf-8') as archive_file:
-        return json.load(archive_file)
+        return normalize_match_history_archive(json.load(archive_file))
 
 def dump_match_history_to_json(reason):
     dump_dir = get_match_history_dump_dir()
@@ -1386,20 +1460,34 @@ def admin_match_history():
 @app.route('/admin/match_history_archives')
 def admin_match_history_archives():
     selected_filename = request.args.get('file')
-    selected_archive = None
     if selected_filename:
-        try:
-            selected_archive = load_match_history_archive(selected_filename)
-        except json.JSONDecodeError:
-            app.logger.exception('Failed to read match history archive JSON')
-            flash('選択した履歴JSONを読み込めませんでした')
-            selected_filename = None
+        return redirect(url_for('admin_match_history_archive_detail', filename=selected_filename))
 
     return render_template(
         'match_history_archives.html',
         archives=list_match_history_archives(),
-        selected_filename=selected_filename,
+        selected_filename=None,
+        selected_archive=None,
+        archive_error=None,
+    )
+
+
+@app.route('/admin/match_history_archives/<path:filename>')
+def admin_match_history_archive_detail(filename):
+    selected_archive = None
+    archive_error = None
+    try:
+        selected_archive = load_match_history_archive(filename)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        app.logger.exception('Failed to read match history archive JSON')
+        archive_error = '読み込みエラー'
+
+    return render_template(
+        'match_history_archives.html',
+        archives=list_match_history_archives(),
+        selected_filename=filename,
         selected_archive=selected_archive,
+        archive_error=archive_error,
     )
 
 # 管理者向けトップページ

--- a/app.py
+++ b/app.py
@@ -951,8 +951,49 @@ def build_match_history_dump(reason):
     }
 
 
+
+
+HISTORY_DUMP_FILENAME_RE = re.compile(r"^match_history_[A-Za-z0-9_]+_\d{8}_\d{6}_\d{6}\.json$")
+
+
+def get_match_history_dump_dir():
+    return os.path.join(app.instance_path, 'history_dumps')
+
+
+def list_match_history_archives():
+    dump_dir = get_match_history_dump_dir()
+    if not os.path.isdir(dump_dir):
+        return []
+
+    archives = []
+    for filename in os.listdir(dump_dir):
+        if not HISTORY_DUMP_FILENAME_RE.match(filename):
+            continue
+        path = os.path.join(dump_dir, filename)
+        if not os.path.isfile(path):
+            continue
+        stat_result = os.stat(path)
+        archives.append({
+            "filename": filename,
+            "size": stat_result.st_size,
+            "modified_at": datetime.fromtimestamp(stat_result.st_mtime, timezone.utc),
+        })
+    return sorted(archives, key=lambda archive: archive["modified_at"], reverse=True)
+
+
+def load_match_history_archive(filename):
+    if not HISTORY_DUMP_FILENAME_RE.match(filename):
+        abort(404)
+
+    archive_path = os.path.join(get_match_history_dump_dir(), filename)
+    if not os.path.isfile(archive_path):
+        abort(404)
+
+    with open(archive_path, encoding='utf-8') as archive_file:
+        return json.load(archive_file)
+
 def dump_match_history_to_json(reason):
-    dump_dir = os.path.join(app.instance_path, 'history_dumps')
+    dump_dir = get_match_history_dump_dir()
     os.makedirs(dump_dir, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')
     dump_path = os.path.join(dump_dir, f'match_history_{reason}_{timestamp}.json')
@@ -1339,6 +1380,26 @@ def admin_match_history():
             for match_round in rounds
             for match in match_round.matches
         },
+    )
+
+
+@app.route('/admin/match_history_archives')
+def admin_match_history_archives():
+    selected_filename = request.args.get('file')
+    selected_archive = None
+    if selected_filename:
+        try:
+            selected_archive = load_match_history_archive(selected_filename)
+        except json.JSONDecodeError:
+            app.logger.exception('Failed to read match history archive JSON')
+            flash('選択した履歴JSONを読み込めませんでした')
+            selected_filename = None
+
+    return render_template(
+        'match_history_archives.html',
+        archives=list_match_history_archives(),
+        selected_filename=selected_filename,
+        selected_archive=selected_archive,
     )
 
 # 管理者向けトップページ

--- a/templates/match_history.html
+++ b/templates/match_history.html
@@ -117,8 +117,9 @@
 </head>
 <body>
     {% include "_flash_messages.html" %}
-    <h1>試合履歴</h1>
-    <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a></p>
+    <h1>現役の試合履歴</h1>
+    <p>現在DBに残っている履歴です。結果入力・修正・JSONダンプ・消去ができます。</p>
+    <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a> / <a href="{{ url_for('admin_match_history_archives') }}">過去のJSONダンプ履歴を見る</a></p>
     <div class="history-actions" aria-label="試合履歴操作">
         <form method="post" action="{{ url_for('dump_match_history') }}">
             <button type="submit">履歴をJSONにダンプ</button>

--- a/templates/match_history_archives.html
+++ b/templates/match_history_archives.html
@@ -31,14 +31,20 @@
         <h2>JSONダンプ一覧</h2>
         {% if archives %}
             <table>
-                <thead><tr><th>ファイル</th><th>更新日時</th><th>サイズ</th><th>操作</th></tr></thead>
+                <thead><tr><th>ファイル</th><th>ダンプ日時</th><th>理由</th><th>ラウンド数</th><th>試合数</th><th>ベンチ記録数</th><th>読み込み状態</th><th>更新日時</th><th>サイズ</th><th>操作</th></tr></thead>
                 <tbody>
                 {% for archive in archives %}
                     <tr>
                         <td>{{ archive.filename }}</td>
+                        <td>{{ archive.dumped_at or '不明' }}</td>
+                        <td>{{ archive.reason or '不明' }}</td>
+                        <td>{{ archive.round_count }}</td>
+                        <td>{{ archive.match_count }}</td>
+                        <td>{{ archive.bench_count }}</td>
+                        <td>{% if archive.status == 'ok' %}正常{% else %}{{ archive.error_message or '読み込みエラー' }}{% endif %}</td>
                         <td>{{ archive.modified_at.strftime('%Y-%m-%d %H:%M') }}</td>
                         <td>{{ archive.size }} bytes</td>
-                        <td><a href="{{ url_for('admin_match_history_archives', file=archive.filename) }}">参照</a></td>
+                        <td><a href="{{ url_for('admin_match_history_archive_detail', filename=archive.filename) }}">参照</a></td>
                     </tr>
                 {% endfor %}
                 </tbody>
@@ -48,14 +54,20 @@
         {% endif %}
     </section>
 
-    {% if selected_archive %}
+    {% if archive_error %}
+        <section class="archive-detail">
+            <h2>アーカイブ内容: {{ selected_filename }}</h2>
+            <p class="empty-message">{{ archive_error }}</p>
+            <p><a href="{{ url_for('admin_match_history_archives') }}">一覧へ戻る</a></p>
+        </section>
+    {% elif selected_archive %}
         <section class="archive-detail">
             <h2>アーカイブ内容: {{ selected_filename }}</h2>
             <p>ダンプ日時: {{ selected_archive.dumped_at or '不明' }} / 理由: {{ selected_archive.reason or '不明' }}</p>
             {% if selected_archive.rounds %}
                 {% for round in selected_archive.rounds %}
                     <section class="archive-round">
-                        <h3>第{{ round.round_number }}試合 <small>{{ round.created_at }}</small></h3>
+                        <h3>第{{ round.round_number or '不明' }}試合 <small>{{ round.created_at or '' }}</small></h3>
                         {% for match in round.matches|sort(attribute='court_number') %}
                             <div class="court-card">
                                 <div class="court-title">{{ match.court_number }}コート</div>

--- a/templates/match_history_archives.html
+++ b/templates/match_history_archives.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>過去の試合履歴アーカイブ</title>
+    <style>
+        body { font-family: sans-serif; line-height: 1.6; margin: 16px; }
+        .archive-list, .archive-detail { margin-top: 16px; }
+        .archive-list table { border-collapse: collapse; width: 100%; }
+        .archive-list th, .archive-list td { border-bottom: 1px solid #ddd; padding: 8px; text-align: left; }
+        .archive-round { border: 1px solid #ccc; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+        .court-card { background: #f8f8f8; border-radius: 6px; padding: 10px; margin: 10px 0; }
+        .court-title { font-weight: bold; }
+        .saved-score-text { white-space: pre-line; color: #555; }
+        .empty-message { color: #666; font-size: 18px; }
+        @media (max-width: 600px) {
+            body { margin: 10px; }
+            .archive-list table, .archive-list tbody, .archive-list tr, .archive-list td { display: block; width: 100%; }
+            .archive-list thead { display: none; }
+            .archive-list td { box-sizing: border-box; }
+        }
+    </style>
+</head>
+<body>
+    {% include "_flash_messages.html" %}
+    <h1>過去の試合履歴アーカイブ</h1>
+    <p><a href="{{ url_for('admin_index') }}">← 管理画面に戻る</a> / <a href="{{ url_for('admin_match_history') }}">現役履歴に戻る</a></p>
+    <p>過去にJSONダンプされた履歴です。基本は参照専用です。</p>
+
+    <section class="archive-list">
+        <h2>JSONダンプ一覧</h2>
+        {% if archives %}
+            <table>
+                <thead><tr><th>ファイル</th><th>更新日時</th><th>サイズ</th><th>操作</th></tr></thead>
+                <tbody>
+                {% for archive in archives %}
+                    <tr>
+                        <td>{{ archive.filename }}</td>
+                        <td>{{ archive.modified_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                        <td>{{ archive.size }} bytes</td>
+                        <td><a href="{{ url_for('admin_match_history_archives', file=archive.filename) }}">参照</a></td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p class="empty-message">JSONダンプ履歴はまだありません。</p>
+        {% endif %}
+    </section>
+
+    {% if selected_archive %}
+        <section class="archive-detail">
+            <h2>アーカイブ内容: {{ selected_filename }}</h2>
+            <p>ダンプ日時: {{ selected_archive.dumped_at or '不明' }} / 理由: {{ selected_archive.reason or '不明' }}</p>
+            {% if selected_archive.rounds %}
+                {% for round in selected_archive.rounds %}
+                    <section class="archive-round">
+                        <h3>第{{ round.round_number }}試合 <small>{{ round.created_at }}</small></h3>
+                        {% for match in round.matches|sort(attribute='court_number') %}
+                            <div class="court-card">
+                                <div class="court-title">{{ match.court_number }}コート</div>
+                                <div>
+                                    [{{ match.team1_player1_card or '' }}]{{ match.team1_player1_name }}・[{{ match.team1_player2_card or '' }}]{{ match.team1_player2_name }}
+                                    vs
+                                    [{{ match.team2_player1_card or '' }}]{{ match.team2_player1_name }}・[{{ match.team2_player2_card or '' }}]{{ match.team2_player2_name }}
+                                </div>
+                                <div>勝者: {% if match.winner_team %}team{{ match.winner_team }}{% else %}未入力{% endif %}</div>
+                                {% if match.team1_score is not none and match.team2_score is not none %}<div>ゲームカウント: {{ match.team1_score }} - {{ match.team2_score }}</div>{% endif %}
+                                {% if match.score_text %}<div class="saved-score-text">{{ match.score_text }}</div>{% endif %}
+                            </div>
+                        {% endfor %}
+                        <div><strong>ベンチ</strong>: {% for bench in round.bench %}[{{ bench.card or '' }}]{{ bench.name }}{% if not loop.last %}, {% endif %}{% else %}なし{% endfor %}</div>
+                    </section>
+                {% endfor %}
+            {% else %}
+                <p class="empty-message">このアーカイブに試合履歴はありません。</p>
+            {% endif %}
+        </section>
+    {% endif %}
+</body>
+</html>

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1390,3 +1390,49 @@ def test_admin_match_result_round_winner_only_rejects_invalid_winner_without_par
         second = app_module.db.session.get(app_module.MatchHistory, match_ids[1])
         assert (first.score_text, first.team1_score, first.team2_score, first.winner_team) == ("19-21", 0, 1, 2)
         assert (second.score_text, second.team1_score, second.team2_score, second.winner_team) == ("21-17", 1, 0, 1)
+
+
+def test_admin_match_history_archives_lists_dumped_json_files(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_dump_fixture(app_module)
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+        assert response.status_code == 302
+
+        html = app_module.app.test_client().get("/admin/match_history_archives").get_data(as_text=True)
+
+        assert "過去の試合履歴アーカイブ" in html
+        assert "過去にJSONダンプされた履歴" in html
+        assert "match_history_manual_dump_" in html
+        assert "参照" in html
+
+
+def test_admin_match_history_archives_displays_selected_archive_readonly(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        participants = add_dump_fixture(app_module)
+        app_module.app.test_client().post("/admin/match_history/dump")
+        _, dump_path = read_latest_dump(app_module)
+        filename = os.path.basename(dump_path)
+
+        html = app_module.app.test_client().get(
+            f"/admin/match_history_archives?file={filename}"
+        ).get_data(as_text=True)
+
+        assert filename in html
+        assert participants[0].name in html
+        assert "21-15" in html
+        assert "履歴をJSONにダンプ" not in html
+        assert "このラウンドの結果を保存" not in html
+
+
+def test_admin_match_history_page_links_to_archives(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        html = app_module.app.test_client().get("/admin/match_history").get_data(as_text=True)
+
+        assert "現在DBに残っている履歴" in html
+        assert "/admin/match_history_archives" in html

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1418,7 +1418,7 @@ def test_admin_match_history_archives_displays_selected_archive_readonly(monkeyp
         filename = os.path.basename(dump_path)
 
         html = app_module.app.test_client().get(
-            f"/admin/match_history_archives?file={filename}"
+            f"/admin/match_history_archives?file={filename}", follow_redirects=True
         ).get_data(as_text=True)
 
         assert filename in html
@@ -1436,3 +1436,123 @@ def test_admin_match_history_page_links_to_archives(monkeypatch, tmp_path):
 
         assert "現在DBに残っている履歴" in html
         assert "/admin/match_history_archives" in html
+
+
+def write_archive_file(app_module, filename, content):
+    dump_dir = Path(app_module.app.instance_path) / "history_dumps"
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    path = dump_dir / filename
+    if isinstance(content, str):
+        path.write_text(content, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(content), encoding="utf-8")
+    return path
+
+
+def test_admin_match_history_archive_detail_path_displays_archive_and_query_redirects(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_dump_fixture(app_module)
+        app_module.app.test_client().post("/admin/match_history/dump")
+        _, dump_path = read_latest_dump(app_module)
+        filename = os.path.basename(dump_path)
+        client = app_module.app.test_client()
+
+        detail_response = client.get(f"/admin/match_history_archives/{filename}")
+        query_response = client.get(f"/admin/match_history_archives?file={filename}")
+
+        html = detail_response.get_data(as_text=True)
+        assert detail_response.status_code == 200
+        assert filename in html
+        assert "player-1" in html
+        assert f'/admin/match_history_archives/{filename}' in html
+        assert query_response.status_code == 302
+        assert query_response.headers["Location"].endswith(f"/admin/match_history_archives/{filename}")
+
+
+def test_admin_match_history_archive_detail_normalizes_unexpected_json_shapes(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    filename = "match_history_manual_dump_20260628_120000_000001.json"
+    write_archive_file(app_module, filename, {
+        "schema_version": 1,
+        "dumped_at": "2026-06-28T12:00:00+00:00",
+        "reason": "manual_dump",
+        "rounds": [
+            {"round_number": 1, "matches": None, "bench": None},
+            "bad-round",
+            {"round_number": 2, "matches": [None, {"court_number": 1}], "bench": [None, {"name": "bench-1"}]},
+        ],
+    })
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().get(f"/admin/match_history_archives/{filename}")
+
+        html = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "第1試合" in html
+        assert "第2試合" in html
+        assert "1コート" in html
+        assert "bench-1" in html
+
+
+def test_admin_match_history_archive_detail_handles_non_list_rounds(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    filename = "match_history_manual_dump_20260628_120000_000002.json"
+    write_archive_file(app_module, filename, {
+        "schema_version": 1,
+        "dumped_at": "2026-06-28T12:00:00+00:00",
+        "reason": "manual_dump",
+        "rounds": {"not": "a-list"},
+    })
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().get(f"/admin/match_history_archives/{filename}")
+
+        assert response.status_code == 200
+        assert "このアーカイブに試合履歴はありません" in response.get_data(as_text=True)
+
+
+def test_admin_match_history_archives_list_shows_metadata_and_corrupt_status(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    good_filename = "match_history_manual_dump_20260628_120000_000003.json"
+    bad_filename = "match_history_manual_dump_20260628_120000_000004.json"
+    write_archive_file(app_module, good_filename, {
+        "schema_version": 1,
+        "dumped_at": "2026-06-28T12:00:00+00:00",
+        "reason": "manual_dump",
+        "rounds": [
+            {"round_number": 1, "matches": [{"court_number": 1}, {"court_number": 2}], "bench": [{"name": "bench-1"}]},
+        ],
+    })
+    write_archive_file(app_module, bad_filename, "{not-json")
+
+    with app_module.app.app_context():
+        response = app_module.app.test_client().get("/admin/match_history_archives")
+
+        html = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "2026-06-28T12:00:00+00:00" in html
+        assert "manual_dump" in html
+        assert ">1</td>" in html
+        assert ">2</td>" in html
+        assert "読み込みエラー" in html
+        assert good_filename in html
+        assert bad_filename in html
+
+
+def test_admin_match_history_archive_rejects_traversal_and_non_json(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    write_archive_file(app_module, "match_history_manual_dump_20260628_120000_000005.json", {"rounds": []})
+    (Path(app_module.app.instance_path) / "history_dumps" / "not_json.txt").write_text("x", encoding="utf-8")
+
+    with app_module.app.app_context():
+        client = app_module.app.test_client()
+        for path in (
+            "/admin/match_history_archives/../config.json",
+            "/admin/match_history_archives/../../app.py",
+            "/admin/match_history_archives/%2e%2e/config.json",
+            "/admin/match_history_archives/subdir/../../app.py",
+            "/admin/match_history_archives/not_json.txt",
+        ):
+            assert client.get(path).status_code == 404


### PR DESCRIPTION
### Motivation
- Provide a safe, read-only interface for previously exported JSON dumps so administrators can inspect past match history without modifying current DB-backed records. 
- Clarify the distinction between the active DB-backed history page and archived JSON dumps in the admin UI.

### Description
- Added helper functions and constants to manage archive files: `HISTORY_DUMP_FILENAME_RE`, `get_match_history_dump_dir()`, `list_match_history_archives()` and `load_match_history_archive()` in `app.py` and switched `dump_match_history_to_json()` to use `get_match_history_dump_dir()`.
- Added a new route `@app.route('/admin/match_history_archives')` that renders a new template `templates/match_history_archives.html` which lists dumped JSON files and shows a selected archive read-only.
- Updated `templates/match_history.html` to clarify it shows the active DB-backed history and to add a link to the archived dumps page.
- Added regression tests in `tests/test_match_history.py` to cover archive listing, archive detail display (read-only), and the link from the active history page.

### Testing
- Ran `pytest tests/test_match_history.py -q` and the test subset passed.
- Ran full test suite with `pytest -q` and all tests passed.
- Verified `python -m py_compile app.py` succeeded with no syntax errors.
- Ran `git diff --check` and it reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40df15c0348333a92163c9dc944529)