### PR TITLE
Prioritize bench fairness in match generation

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -1,9 +1,67 @@
 import random
 
-def generate_matches(participants, court_count):
-    # activeで絞って、games_playedで昇順ソート（回数少ない人優先）
+from flask import has_app_context
+
+from models import MatchRound
+from utils.match_state import load_match_state
+
+
+def get_previous_bench_ids():
+    """Return participant IDs from the latest confirmed match state's bench."""
+    return set(load_match_state().get("bench", []))
+
+
+def get_three_consecutive_player_ids():
+    """Return participant IDs that played in all of the latest three persisted rounds."""
+    if not has_app_context():
+        return set()
+
+    latest_rounds = MatchRound.query.order_by(MatchRound.id.desc()).limit(3).all()
+    if len(latest_rounds) < 3:
+        return set()
+
+    played_by_round = []
+    for round_record in latest_rounds:
+        player_ids = set()
+        for match in round_record.matches:
+            player_ids.update(
+                (
+                    match.team1_player1_id,
+                    match.team1_player2_id,
+                    match.team2_player1_id,
+                    match.team2_player2_id,
+                )
+            )
+        played_by_round.append(player_ids)
+
+    return set.intersection(*played_by_round) if played_by_round else set()
+
+
+def generate_matches(
+    participants, court_count, previous_bench_ids=None, three_consecutive_player_ids=None
+):
+    # activeで絞って、優先順位でソート
     candidates = [p for p in participants if p.active]
-    candidates.sort(key=lambda p: p.games_played)
+
+    if previous_bench_ids is None:
+        previous_bench_ids = get_previous_bench_ids()
+    else:
+        previous_bench_ids = set(previous_bench_ids)
+
+    if three_consecutive_player_ids is None:
+        three_consecutive_player_ids = get_three_consecutive_player_ids()
+    else:
+        three_consecutive_player_ids = set(three_consecutive_player_ids)
+
+    # 同順位の中では既存のランダム性を残す
+    random.shuffle(candidates)
+    candidates.sort(
+        key=lambda p: (
+            p.id not in previous_bench_ids,
+            p.id in three_consecutive_player_ids,
+            p.games_played,
+        )
+    )
 
     max_players = min(len(candidates), court_count * 4)
     selected = candidates[:max_players]
@@ -18,6 +76,6 @@ def generate_matches(participants, court_count):
             matches.append(group)
             # ゲームに出た人はgames_playedを+1
             for p in group:
-                p.games_played +=1
+                p.games_played += 1
 
     return matches, bench

--- a/logic.py
+++ b/logic.py
@@ -16,7 +16,15 @@ def get_three_consecutive_player_ids():
     if not has_app_context():
         return set()
 
-    latest_rounds = MatchRound.query.order_by(MatchRound.id.desc()).limit(3).all()
+    match_count = int(load_match_state().get("match_count", 0) or 0)
+    if match_count < 3:
+        return set()
+
+    latest_rounds = (
+        MatchRound.query.order_by(MatchRound.id.desc())
+        .limit(min(match_count, 3))
+        .all()
+    )
     if len(latest_rounds) < 3:
         return set()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 import pytest
 from flask import Flask
 
-from logic import generate_matches
+import logic as logic_module
+from logic import generate_matches, get_three_consecutive_player_ids
 from models import db, MatchHistory, MatchRound
 
 
@@ -101,8 +102,16 @@ def test_generate_matches_does_not_select_inactive_previous_bench_players():
     assert bench == []
 
 
-def test_generate_matches_benches_three_consecutive_players_when_bench_slots_exist(logic_app):
+def test_generate_matches_benches_three_consecutive_players_when_bench_slots_exist(
+    logic_app, monkeypatch
+):
     participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 3},
+    )
+
     with logic_app.app_context():
         for round_number in range(1, 4):
             add_round(round_number, [1, 2, 3, 4])
@@ -167,3 +176,65 @@ def test_generate_matches_keeps_existing_return_shape():
     assert isinstance(bench, list)
     assert all(hasattr(player, "id") for match in matches for player in match)
     assert all(hasattr(player, "id") for player in bench)
+
+
+def test_three_consecutive_ignores_persisted_rounds_when_match_count_is_less_than_three(
+    logic_app, monkeypatch
+):
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        for match_count in (0, 1, 2):
+            monkeypatch.setattr(
+                logic_module,
+                "load_match_state",
+                lambda count=match_count: {
+                    "match_active": False,
+                    "matches": [],
+                    "bench": [],
+                    "match_count": count,
+                },
+            )
+
+            assert get_three_consecutive_player_ids() == set()
+
+
+def test_three_consecutive_uses_current_run_after_three_rounds(logic_app, monkeypatch):
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 3},
+    )
+
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [5, 6, 7, 8])
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        assert get_three_consecutive_player_ids() == {1, 2, 3, 4}
+
+
+def test_generate_matches_after_reset_does_not_bench_players_for_old_streaks(
+    logic_app, monkeypatch
+):
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+    participants[4].games_played = 99
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        matches, bench = generate_matches(participants, court_count=1)
+
+    assert flatten_match_ids(matches) == {1, 2, 3, 4}
+    assert {player.id for player in bench} == {5}

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -12,7 +12,7 @@ def make_player(player_id, games_played=0, active=True):
     return SimpleNamespace(id=player_id, games_played=games_played, active=active)
 
 
-def test_generate_matches_uses_only_active_players_and_benches_over_capacity():
+def test_generate_matches_uses_only_active_players_and_benches_over_capacity(monkeypatch):
     participants = [
         make_player(1, games_played=0),
         make_player(2, games_played=0),
@@ -21,6 +21,9 @@ def test_generate_matches_uses_only_active_players_and_benches_over_capacity():
         make_player(5, games_played=2),
         make_player(6, games_played=0, active=False),
     ]
+
+    monkeypatch.setattr("logic.get_previous_bench_ids", lambda: set())
+    monkeypatch.setattr("logic.get_three_consecutive_player_ids", lambda: set())
 
     matches, bench = generate_matches(participants, court_count=1)
 
@@ -123,9 +126,17 @@ def test_generate_matches_benches_three_consecutive_players_when_bench_slots_exi
     assert 5 in flatten_match_ids(matches)
 
 
-def test_generate_matches_does_not_treat_less_than_three_rounds_as_three_consecutive(logic_app):
+def test_generate_matches_does_not_treat_less_than_three_rounds_as_three_consecutive(
+    logic_app, monkeypatch
+):
     participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
     participants[4].games_played = 99
+    monkeypatch.setattr("logic.get_previous_bench_ids", lambda: set())
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 2},
+    )
     with logic_app.app_context():
         add_round(1, [1, 2, 3, 4])
         add_round(2, [1, 2, 3, 4])

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
+import pytest
+from flask import Flask
+
 from logic import generate_matches
+from models import db, MatchHistory, MatchRound
 
 
 def make_player(player_id, games_played=0, active=True):
@@ -37,3 +41,129 @@ def test_generate_matches_increments_games_played_for_matched_players_only():
         assert player.games_played == 1
     for player in bench:
         assert player.games_played == 0
+
+
+@pytest.fixture
+def logic_app(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path / 'logic.db'}"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def flatten_match_ids(matches):
+    return {player.id for match in matches for player in match}
+
+
+def add_round(round_number, player_ids):
+    round_record = MatchRound(round_number=round_number)
+    db.session.add(round_record)
+    db.session.flush()
+    db.session.add(
+        MatchHistory(
+            round_id=round_record.id,
+            court_number=1,
+            team1_player1_id=player_ids[0],
+            team1_player2_id=player_ids[1],
+            team2_player1_id=player_ids[2],
+            team2_player2_id=player_ids[3],
+        )
+    )
+    return round_record
+
+
+def test_generate_matches_prioritizes_active_previous_bench_players():
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+    participants[4].games_played = 99
+
+    matches, bench = generate_matches(participants, court_count=1, previous_bench_ids={5})
+
+    assert 5 in flatten_match_ids(matches)
+    assert 5 not in {player.id for player in bench}
+    assert len(bench) == 1
+
+
+def test_generate_matches_does_not_select_inactive_previous_bench_players():
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 5)]
+    inactive_previous_bench = make_player(5, games_played=0, active=False)
+    participants.append(inactive_previous_bench)
+
+    matches, bench = generate_matches(participants, court_count=1, previous_bench_ids={5})
+
+    selected_or_benched_ids = flatten_match_ids(matches) | {player.id for player in bench}
+    assert 5 not in selected_or_benched_ids
+    assert len(matches) == 1
+    assert bench == []
+
+
+def test_generate_matches_benches_three_consecutive_players_when_bench_slots_exist(logic_app):
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        matches, bench = generate_matches(participants, court_count=1)
+
+    assert {player.id for player in bench} <= {1, 2, 3, 4}
+    assert 5 in flatten_match_ids(matches)
+
+
+def test_generate_matches_does_not_treat_less_than_three_rounds_as_three_consecutive(logic_app):
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+    participants[4].games_played = 99
+    with logic_app.app_context():
+        add_round(1, [1, 2, 3, 4])
+        add_round(2, [1, 2, 3, 4])
+        db.session.commit()
+
+        matches, bench = generate_matches(participants, court_count=1)
+
+    assert {player.id for player in bench} == {5}
+    assert flatten_match_ids(matches) == {1, 2, 3, 4}
+
+
+def test_generate_matches_selects_all_active_players_when_no_bench_slots_even_if_three_consecutive():
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 5)]
+
+    matches, bench = generate_matches(
+        participants,
+        court_count=1,
+        three_consecutive_player_ids={1, 2, 3, 4},
+    )
+
+    assert len(matches) == 1
+    assert flatten_match_ids(matches) == {1, 2, 3, 4}
+    assert bench == []
+
+
+def test_generate_matches_succeeds_when_three_consecutive_players_exceed_bench_slots():
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 7)]
+
+    matches, bench = generate_matches(
+        participants,
+        court_count=1,
+        three_consecutive_player_ids={1, 2, 3, 4, 5},
+    )
+
+    assert len(matches) == 1
+    assert len(bench) == 2
+    assert flatten_match_ids(matches) | {player.id for player in bench} == set(range(1, 7))
+
+
+def test_generate_matches_keeps_existing_return_shape():
+    participants = [make_player(player_id, games_played=0) for player_id in range(1, 6)]
+
+    matches, bench = generate_matches(participants, court_count=1)
+
+    assert isinstance(matches, list)
+    assert all(isinstance(match, list) for match in matches)
+    assert all(len(match) == 4 for match in matches)
+    assert isinstance(bench, list)
+    assert all(hasattr(player, "id") for match in matches for player in match)
+    assert all(hasattr(player, "id") for player in bench)


### PR DESCRIPTION
### Motivation
- Reduce bench bias so players who were benched previously are favored to play next and players who have played three consecutive rounds are preferentially benched when possible.
- Apply both rules as "できる限り" (soft constraints) so behavior remains correct when participant counts or court capacity prevent full enforcement.
- Keep existing `matches, bench` return shape and preserve `games_played` increment semantics.

### Description
- Added `get_previous_bench_ids()` which reads the confirmed `bench` from `match_state.json` via `load_match_state()` to prefer previous benched players when selecting participants. 
- Added `get_three_consecutive_player_ids()` which inspects the latest three persisted `MatchRound` records and computes participants who appeared in all three `MatchHistory` entries so they can be deprioritized for selection. 
- Updated `generate_matches(...)` signature to accept optional `previous_bench_ids` and `three_consecutive_player_ids`, filter only `active` participants, preserve random tie-breaking (`random.shuffle`) and sort candidates by the priority key `(p.id not in previous_bench_ids, p.id in three_consecutive_player_ids, p.games_played)`. 
- Selection, benching, `games_played` increment, and return format are preserved (still returns `matches, bench`), and the new logic respects the specified exceptions (no bench when participants <= `court_count * 4`, inactive players excluded, soft enforcement when constraints conflict). 
- Added regression tests in `tests/test_logic.py` to cover previous-bench priority, inactive previous-bench exclusion, three-consecutive detection and behavior, fewer-than-three-rounds handling, no-bench scenario, over-capacity three-consecutive scenario, and return-shape compatibility.

### Testing
- Ran `pytest tests/test_logic.py -q` and the tests for the new behavior passed. 
- Ran the full test suite with `pytest` and all tests passed (`145 passed`). 
- Verified that the new logic preserves existing return shapes and increments `games_played` only for matched players via the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435cf965808333b1932b4e5843926e)