### PR TITLE
Make consecutive-play bench-priority configurable from admin settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import selectinload
 from flask import send_from_directory
 from flask import send_file
 import qrcode
-from logic import generate_matches
+from logic import generate_matches, normalize_consecutive_play_limit
 from itertools import zip_longest
 from utils.match_state import load_match_state, save_match_state_full
 from utils.draft_state import clear_draft_state, get_active_draft, save_draft_state
@@ -158,6 +158,9 @@ def normalize_config(config):
     normalized = dict(config)
     normalized["score_input_mode"] = normalize_score_input_mode(config.get("score_input_mode"))
     normalized["scoring_system"] = normalize_scoring_system(config.get("scoring_system"))
+    normalized["consecutive_play_limit"] = normalize_consecutive_play_limit(
+        config.get("consecutive_play_limit")
+    )
     normalized.setdefault("paypay_links", {})
     normalized.setdefault("level_map", {})
     normalized.setdefault("gender_weight", {})
@@ -810,6 +813,9 @@ def admin_settings():
                 "female": parse_float(request.form.get('weight_female'), current_config["gender_weight"].get("female", 0.9))
             },
             "score_input_mode": normalize_score_input_mode(request.form.get('score_input_mode')),
+            "consecutive_play_limit": normalize_consecutive_play_limit(
+                request.form.get('consecutive_play_limit')
+            ),
             "scoring_system": normalize_scoring_system({
                 "points_per_game": request.form.get('points_per_game'),
                 "games_per_match": request.form.get('games_per_match'),

--- a/config.example.json
+++ b/config.example.json
@@ -18,5 +18,6 @@
     "games_per_match": 1,
     "deuce_enabled": false,
     "max_points": 21
-  }
+  },
+  "consecutive_play_limit": 3
 }

--- a/logic.py
+++ b/logic.py
@@ -1,3 +1,4 @@
+import json
 import random
 
 from flask import has_app_context
@@ -5,27 +6,58 @@ from flask import has_app_context
 from models import MatchRound
 from utils.match_state import load_match_state
 
+DEFAULT_CONSECUTIVE_PLAY_LIMIT = 3
+MIN_CONSECUTIVE_PLAY_LIMIT = 2
+MAX_CONSECUTIVE_PLAY_LIMIT = 10
+
+
+def normalize_consecutive_play_limit(value):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_CONSECUTIVE_PLAY_LIMIT
+    if parsed < MIN_CONSECUTIVE_PLAY_LIMIT or parsed > MAX_CONSECUTIVE_PLAY_LIMIT:
+        return DEFAULT_CONSECUTIVE_PLAY_LIMIT
+    return parsed
+
+
+def load_consecutive_play_limit():
+    try:
+        with open('config.json', 'r', encoding='utf-8') as f:
+            config = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return DEFAULT_CONSECUTIVE_PLAY_LIMIT
+    if not isinstance(config, dict):
+        return DEFAULT_CONSECUTIVE_PLAY_LIMIT
+    return normalize_consecutive_play_limit(config.get('consecutive_play_limit'))
+
 
 def get_previous_bench_ids():
     """Return participant IDs from the latest confirmed match state's bench."""
     return set(load_match_state().get("bench", []))
 
 
-def get_three_consecutive_player_ids():
-    """Return participant IDs that played in all of the latest three persisted rounds."""
+def get_consecutive_player_ids(consecutive_play_limit=None):
+    """Return participant IDs that played in all latest configured persisted rounds."""
     if not has_app_context():
         return set()
 
+    limit = (
+        normalize_consecutive_play_limit(consecutive_play_limit)
+        if consecutive_play_limit is not None
+        else load_consecutive_play_limit()
+    )
+
     match_count = int(load_match_state().get("match_count", 0) or 0)
-    if match_count < 3:
+    if match_count < limit:
         return set()
 
     latest_rounds = (
         MatchRound.query.order_by(MatchRound.id.desc())
-        .limit(min(match_count, 3))
+        .limit(min(match_count, limit))
         .all()
     )
-    if len(latest_rounds) < 3:
+    if len(latest_rounds) < limit:
         return set()
 
     played_by_round = []
@@ -45,8 +77,17 @@ def get_three_consecutive_player_ids():
     return set.intersection(*played_by_round) if played_by_round else set()
 
 
+def get_three_consecutive_player_ids():
+    """Backward-compatible wrapper for the former fixed-three helper."""
+    return get_consecutive_player_ids(3)
+
+
 def generate_matches(
-    participants, court_count, previous_bench_ids=None, three_consecutive_player_ids=None
+    participants,
+    court_count,
+    previous_bench_ids=None,
+    consecutive_player_ids=None,
+    three_consecutive_player_ids=None,
 ):
     # activeで絞って、優先順位でソート
     candidates = [p for p in participants if p.active]
@@ -56,17 +97,20 @@ def generate_matches(
     else:
         previous_bench_ids = set(previous_bench_ids)
 
-    if three_consecutive_player_ids is None:
-        three_consecutive_player_ids = get_three_consecutive_player_ids()
+    if consecutive_player_ids is None and three_consecutive_player_ids is not None:
+        consecutive_player_ids = three_consecutive_player_ids
+
+    if consecutive_player_ids is None:
+        consecutive_player_ids = get_consecutive_player_ids()
     else:
-        three_consecutive_player_ids = set(three_consecutive_player_ids)
+        consecutive_player_ids = set(consecutive_player_ids)
 
     # 同順位の中では既存のランダム性を残す
     random.shuffle(candidates)
     candidates.sort(
         key=lambda p: (
             p.id not in previous_bench_ids,
-            p.id in three_consecutive_player_ids,
+            p.id in consecutive_player_ids,
             p.games_played,
         )
     )

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -36,6 +36,12 @@
     <input type="text" name="weight_female" value="{{ config.gender_weight.female }}">
     <hr>
 
+    <h3>組み合わせ生成設定</h3>
+    <label>連続出場ベンチ優先回数</label>
+    <input type="number" name="consecutive_play_limit" min="2" max="10" value="{{ config.consecutive_play_limit }}">
+    <p>指定回数以上連続で試合に入った参加者は、次回できる限りベンチに回します。推奨範囲: 2〜10</p>
+    <hr>
+
     <h3>勝敗・スコア入力設定</h3>
     <label>勝敗・スコア入力モード</label>
     <select name="score_input_mode">

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,10 +1,16 @@
 from types import SimpleNamespace
 
+import json
+
 import pytest
 from flask import Flask
 
 import logic as logic_module
-from logic import generate_matches, get_three_consecutive_player_ids
+from logic import (
+    generate_matches,
+    get_consecutive_player_ids,
+    get_three_consecutive_player_ids,
+)
 from models import db, MatchHistory, MatchRound
 
 
@@ -23,7 +29,7 @@ def test_generate_matches_uses_only_active_players_and_benches_over_capacity(mon
     ]
 
     monkeypatch.setattr("logic.get_previous_bench_ids", lambda: set())
-    monkeypatch.setattr("logic.get_three_consecutive_player_ids", lambda: set())
+    monkeypatch.setattr("logic.get_consecutive_player_ids", lambda: set())
 
     matches, bench = generate_matches(participants, court_count=1)
 
@@ -227,6 +233,83 @@ def test_three_consecutive_uses_current_run_after_three_rounds(logic_app, monkey
         db.session.commit()
 
         assert get_three_consecutive_player_ids() == {1, 2, 3, 4}
+
+
+def write_logic_config(tmp_path, value_marker):
+    config = {} if value_marker is None else {"consecutive_play_limit": value_marker}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_consecutive_player_ids_default_to_three_when_config_key_missing(
+    logic_app, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    write_logic_config(tmp_path, None)
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 3},
+    )
+
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        assert get_consecutive_player_ids() == {1, 2, 3, 4}
+
+
+def test_consecutive_player_ids_uses_two_round_limit(logic_app, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    write_logic_config(tmp_path, 2)
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 2},
+    )
+
+    with logic_app.app_context():
+        add_round(1, [1, 2, 3, 4])
+        add_round(2, [1, 2, 3, 4])
+        db.session.commit()
+
+        assert get_consecutive_player_ids() == {1, 2, 3, 4}
+
+
+def test_consecutive_player_ids_uses_four_round_limit(logic_app, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    write_logic_config(tmp_path, 4)
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 3},
+    )
+
+    with logic_app.app_context():
+        for round_number in range(1, 4):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        assert get_consecutive_player_ids() == set()
+
+
+def test_consecutive_player_ids_ignores_old_history_when_match_count_below_configured_limit(
+    logic_app, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    write_logic_config(tmp_path, 4)
+    monkeypatch.setattr(
+        logic_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 3},
+    )
+
+    with logic_app.app_context():
+        for round_number in range(1, 5):
+            add_round(round_number, [1, 2, 3, 4])
+        db.session.commit()
+
+        assert get_consecutive_player_ids() == set()
 
 
 def test_generate_matches_after_reset_does_not_bench_players_for_old_streaks(

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -456,6 +456,7 @@ def test_score_config_defaults_and_invalid_values(monkeypatch, tmp_path):
 
     assert app_module.load_config()["score_input_mode"] == "winner_only"
     assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": False, "max_points": 21}
+    assert app_module.load_config()["consecutive_play_limit"] == 3
 
     (tmp_path / "config.json").write_text(json.dumps({
         "score_input_mode": "bad",
@@ -464,6 +465,7 @@ def test_score_config_defaults_and_invalid_values(monkeypatch, tmp_path):
 
     assert app_module.load_config()["score_input_mode"] == "winner_only"
     assert app_module.load_config()["scoring_system"] == {"points_per_game": 21, "games_per_match": 1, "deuce_enabled": False, "max_points": 21}
+    assert app_module.load_config()["consecutive_play_limit"] == 3
 
 
 def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path):
@@ -473,6 +475,7 @@ def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path)
     html = client.get("/admin/settings").get_data(as_text=True)
     assert "勝敗・スコア入力モード" in html
     assert "1ゲームのポイント数" in html
+    assert "連続出場ベンチ優先回数" in html
 
     response = client.post("/admin/settings", data={
         "paypay_adults": "adults",
@@ -483,6 +486,7 @@ def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path)
         "weight_male": "1.0",
         "weight_female": "0.9",
         "score_input_mode": "score",
+        "consecutive_play_limit": "4",
         "points_per_game": "15",
         "games_per_match": "3",
         "deuce_enabled": "on",
@@ -494,6 +498,30 @@ def test_admin_settings_displays_and_updates_score_config(monkeypatch, tmp_path)
     assert saved["score_input_mode"] == "score"
     assert saved["scoring_system"] == {"points_per_game": 15, "games_per_match": 3, "deuce_enabled": True, "max_points": 30}
     assert saved["paypay_links"] == {"adults": "adults", "students": "students"}
+    assert saved["consecutive_play_limit"] == 4
+
+
+def test_admin_settings_safely_handles_invalid_consecutive_play_limit(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    response = app_module.app.test_client().post("/admin/settings", data={
+        "paypay_adults": "adults",
+        "paypay_students": "students",
+        "level_beginner": "1",
+        "level_intermediate": "2",
+        "level_advanced": "3",
+        "weight_male": "1.0",
+        "weight_female": "0.9",
+        "score_input_mode": "winner_only",
+        "consecutive_play_limit": "99",
+        "points_per_game": "21",
+        "games_per_match": "1",
+        "max_points": "21",
+    })
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["consecutive_play_limit"] == 3
 
 
 def add_history_match(app_module, team1_score=10, team2_score=8, winner_team=1):


### PR DESCRIPTION
### Motivation
- Make the fixed “3 consecutive rounds” bench-priority rule configurable because optimal streak limits vary by participant count, court count and event length. 
- Expose the value to administrators so it can be tuned at runtime without code edits.

### Description
- Add a normalized `consecutive_play_limit` setting (default 3, allowed range 2–10) and support functions (`normalize_consecutive_play_limit`, `load_consecutive_play_limit`) so missing/invalid values fallback safely to 3. (files: `logic.py`, `app.py`)
- Replace the hard-coded three-round lookup with a generic `get_consecutive_player_ids()` that uses the configured limit, and keep `get_three_consecutive_player_ids()` as a backward-compatible wrapper. `generate_matches()` now accepts/uses the new consecutive-player set without changing its return shape. (file: `logic.py`)
- Add the `consecutive_play_limit` field to `config.example.json` and include an integer input (min=2, max=10) labeled “連続出場ベンチ優先回数” on the admin settings page so admins can update and persist the setting. (files: `config.example.json`, `templates/admin_settings.html`, `app.py`)
- Update and add unit tests to cover default behavior when the config key is missing, behavior for limits 2/3/4, the `match_count` boundary after reset, admin settings persistence, and invalid input handling. (files: `tests/test_logic.py`, `tests/test_match_history.py`)

### Testing
- Ran targeted tests: `pytest tests/test_logic.py` and selected `tests/test_match_history.py` scenarios for config defaults and admin settings; the added/modified tests passed.
- Ran the full test suite with `pytest`, and all tests passed (153 passed).
- Manually verified the new field renders on `/admin/settings` (checked via HTTP request) and that saving the form persists a validated integer into `config.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45f4817540833393454c77bd3dcc78)