### PR TITLE
Add draft-scoped fixed-pair support to match edit and swap

### DIFF
--- a/app.py
+++ b/app.py
@@ -442,6 +442,85 @@ def match_form():
     
     return redirect(url_for('edit_matches', mode=mode))
 
+
+
+def get_current_pair(match_ids, participant_id):
+    for match_index, group in enumerate(match_ids):
+        for start in range(0, len(group), 2):
+            pair = group[start:start + 2]
+            if participant_id in pair:
+                return match_index, start, pair
+    return None
+
+
+def normalize_fixed_pairs(raw_fixed_pairs, match_ids):
+    if not isinstance(raw_fixed_pairs, list):
+        return []
+
+    used_ids = set()
+    normalized = []
+    for raw_pair in raw_fixed_pairs:
+        if not isinstance(raw_pair, (list, tuple)) or len(raw_pair) != 2:
+            continue
+        try:
+            pair_ids = [int(raw_pair[0]), int(raw_pair[1])]
+        except (TypeError, ValueError):
+            continue
+        if pair_ids[0] == pair_ids[1] or any(pid in used_ids for pid in pair_ids):
+            continue
+
+        position_1 = get_current_pair(match_ids, pair_ids[0])
+        position_2 = get_current_pair(match_ids, pair_ids[1])
+        if (
+            position_1 is None
+            or position_2 is None
+            or position_1[0] != position_2[0]
+            or position_1[1] != position_2[1]
+            or len(position_1[2]) != 2
+        ):
+            continue
+
+        normalized_pair = sorted(pair_ids)
+        normalized.append(normalized_pair)
+        used_ids.update(normalized_pair)
+
+    return normalized
+
+
+def get_fixed_pair_for_player(fixed_pairs, participant_id):
+    for pair in fixed_pairs:
+        if participant_id in pair:
+            return pair
+    return None
+
+
+def same_current_pair(match_ids, id1, id2):
+    position_1 = get_current_pair(match_ids, id1)
+    position_2 = get_current_pair(match_ids, id2)
+    return (
+        position_1 is not None
+        and position_2 is not None
+        and position_1[0] == position_2[0]
+        and position_1[1] == position_2[1]
+        and len(position_1[2]) == 2
+    )
+
+
+def swap_pair_positions(match_ids, id1, id2):
+    position_1 = get_current_pair(match_ids, id1)
+    position_2 = get_current_pair(match_ids, id2)
+    if position_1 is None or position_2 is None:
+        return False
+
+    match_index_1, start_1, pair_1 = position_1
+    match_index_2, start_2, pair_2 = position_2
+    if len(pair_1) != 2 or len(pair_2) != 2:
+        return False
+
+    match_ids[match_index_1][start_1:start_1 + 2] = pair_2
+    match_ids[match_index_2][start_2:start_2 + 2] = pair_1
+    return True
+
 @app.route('/match/edit')
 def edit_matches():
     mode = request.args.get('mode', 'admin')
@@ -456,6 +535,7 @@ def edit_matches():
 
     match_ids = draft['matches']
     bench_ids = draft['bench']
+    fixed_pairs = normalize_fixed_pairs(draft.get('fixed_pairs'), match_ids)
 
     participants = {p.id: p for p in Participant.query.all()}
     
@@ -472,8 +552,11 @@ def edit_matches():
         return p
 
     # 参加者を加工したものに変換
-    matches = [[mark_bench_player(participants[pid]) for pid in group] for group in match_ids]
-    bench = [mark_bench_player(participants[pid]) for pid in bench_ids]
+    matches = [
+        [mark_bench_player(participants[pid]) for pid in group if pid in participants]
+        for group in match_ids
+    ]
+    bench = [mark_bench_player(participants[pid]) for pid in bench_ids if pid in participants]
 
     court_count = get_draft_court_count(draft)
     match_count = get_match_count()
@@ -502,7 +585,9 @@ def edit_matches():
         card_to_filename=card_to_filename,
         match_count=match_count,
         court_count=court_count,
-        mode=mode
+        mode=mode,
+        fixed_player_ids={pid for pair in fixed_pairs for pid in pair},
+        fixed_pair_keys={tuple(pair) for pair in fixed_pairs},
     )
 
 @app.route('/match/swap', methods=['POST'])
@@ -514,7 +599,10 @@ def swap_players():
     if len(selected_ids) != 2:
         return redirect(url_for('edit_matches', mode=mode))  # 2人以外選ばれてたら無視
 
-    id1, id2 = map(int, selected_ids)
+    try:
+        id1, id2 = map(int, selected_ids)
+    except ValueError:
+        return redirect(url_for('edit_matches', mode=mode))
 
     # 共有中の未確定 draft を正として現在の状態を取得
     draft = get_active_draft()
@@ -523,6 +611,51 @@ def swap_players():
 
     match_ids = draft['matches']
     bench_ids = draft['bench']
+    fixed_pairs = normalize_fixed_pairs(draft.get('fixed_pairs'), match_ids)
+
+    fixed_pair_1 = get_fixed_pair_for_player(fixed_pairs, id1)
+    fixed_pair_2 = get_fixed_pair_for_player(fixed_pairs, id2)
+    bench_id_set = set(bench_ids)
+
+    if same_current_pair(match_ids, id1, id2):
+        selected_pair = sorted([id1, id2])
+        if selected_pair in fixed_pairs:
+            fixed_pairs = [pair for pair in fixed_pairs if pair != selected_pair]
+            flash('固定ペアを解除しました')
+        else:
+            fixed_pairs = [pair for pair in fixed_pairs if id1 not in pair and id2 not in pair]
+            fixed_pairs.append(selected_pair)
+            fixed_pairs = normalize_fixed_pairs(fixed_pairs, match_ids)
+            flash('固定ペアにしました')
+
+        save_draft_state(
+            match_ids,
+            bench_ids,
+            court_count=draft.get('court_count'),
+            fixed_pairs=fixed_pairs,
+        )
+        return redirect(url_for('edit_matches', mode=mode))
+
+    if (fixed_pair_1 or fixed_pair_2) and (id1 in bench_id_set or id2 in bench_id_set):
+        flash('固定ペアはベンチ参加者と個別に入れ替えできません')
+        save_draft_state(
+            match_ids,
+            bench_ids,
+            court_count=draft.get('court_count'),
+            fixed_pairs=fixed_pairs,
+        )
+        return redirect(url_for('edit_matches', mode=mode))
+
+    if fixed_pair_1 or fixed_pair_2:
+        swap_pair_positions(match_ids, id1, id2)
+        fixed_pairs = normalize_fixed_pairs(fixed_pairs, match_ids)
+        save_draft_state(
+            match_ids,
+            bench_ids,
+            court_count=draft.get('court_count'),
+            fixed_pairs=fixed_pairs,
+        )
+        return redirect(url_for('edit_matches', mode=mode))
 
     # 両方をまとめて探索・入れ替え
     all_groups = match_ids + [bench_ids]  # 最後の1枠は bench 扱い
@@ -543,6 +676,7 @@ def swap_players():
         match_ids,
         new_bench_ids,
         court_count=draft.get('court_count'),
+        fixed_pairs=fixed_pairs,
     )
 
     return redirect(url_for('edit_matches', mode=mode))

--- a/templates/match_edit.html
+++ b/templates/match_edit.html
@@ -87,6 +87,8 @@
 
 <h1>次の組み合わせ(編集中) ■ {{ match_count }} 回目</h1>
 
+{% include "_flash_messages.html" %}
+
 <nav class="button-row">
     <a href="{{ url_for('match_result', mode=mode) }}" class="btn">▶ 確定済み組み合わせを表示</a>
 </nav>

--- a/templates/match_edit.html
+++ b/templates/match_edit.html
@@ -65,6 +65,23 @@
         background-color: #eef;
         border-radius: 5px;
     }
+
+    .fixed-player {
+        border: 2px solid #f0ad4e;
+        border-radius: 8px;
+        background-color: #fff8e5;
+    }
+
+    .fixed-badge {
+        display: inline-block;
+        margin-top: 4px;
+        padding: 2px 6px;
+        border-radius: 999px;
+        background-color: #f0ad4e;
+        color: #fff;
+        font-size: 12px;
+        font-weight: bold;
+    }
 </style>
 {% include "_button_styles.html" %}
 
@@ -85,9 +102,10 @@
                     <div class="players-row">
                         {% for p in match[:2] %}
                             <div class="player-card">
-                                <div class="player-label selectable" data-id="{{ p.id }}">
+                                <div class="player-label selectable{% if p.id in fixed_player_ids %} fixed-player{% endif %}" data-id="{{ p.id }}">
                                     <img src="{{ url_for('static', filename='cards/' + card_to_filename(p.card)) }}"><br>
                                     {{ p.name }} ({{ p.games_played }})
+                                    {% if p.id in fixed_player_ids %}<br><span class="fixed-badge">固定</span>{% endif %}
                                 </div>
                             </div>
                         {% endfor %}
@@ -103,9 +121,10 @@
                     <div class="players-row">
                         {% for p in match[2:] %}
                             <div class="player-card">
-                                <div class="player-label selectable" data-id="{{ p.id }}">
+                                <div class="player-label selectable{% if p.id in fixed_player_ids %} fixed-player{% endif %}" data-id="{{ p.id }}">
                                     <img src="{{ url_for('static', filename='cards/' + card_to_filename(p.card)) }}"><br>
                                     {{ p.name }} ({{ p.games_played }})
+                                    {% if p.id in fixed_player_ids %}<br><span class="fixed-badge">固定</span>{% endif %}
                                 </div>
                             </div>
                         {% endfor %}

--- a/tests/test_flash_messages.py
+++ b/tests/test_flash_messages.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 
@@ -86,3 +87,54 @@ def test_reset_db_flash_is_rendered_on_admin_settings(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     assert "参加者データと試合情報をすべて削除しました" in response.get_data(as_text=True)
+
+
+def test_match_edit_includes_flash_messages_partial():
+    template = Path(__file__).resolve().parents[1] / "templates" / "match_edit.html"
+
+    assert '{% include "_flash_messages.html" %}' in template.read_text(encoding="utf-8")
+
+
+def test_fixed_pair_bench_swap_rejection_flash_is_rendered(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path)
+    participants = [
+        SimpleNamespace(id=1, card="♥A", name="player-1", games_played=0),
+        SimpleNamespace(id=2, card="♥2", name="player-2", games_played=0),
+        SimpleNamespace(id=3, card="♥3", name="player-3", games_played=0),
+        SimpleNamespace(id=4, card="♥4", name="player-4", games_played=0),
+        SimpleNamespace(id=5, card="♥5", name="player-5", games_played=0),
+    ]
+    monkeypatch.setattr(
+        app_module,
+        "Participant",
+        SimpleNamespace(query=SimpleNamespace(all=lambda: participants)),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    monkeypatch.setattr(app_module, "get_match_count", lambda: 1)
+    monkeypatch.setattr(app_module, "calculate_participant_win_stats", lambda: {})
+    monkeypatch.setattr(
+        app_module,
+        "calculate_pair_score",
+        lambda pair, *_: SimpleNamespace(
+            players=[SimpleNamespace(score=0), SimpleNamespace(score=0)],
+            total_score=0,
+        ),
+    )
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "fixed_pairs": [[1, 2]]}),
+        encoding="utf-8",
+    )
+    client = app_module.app.test_client()
+
+    response = client.post(
+        "/match/swap",
+        data={"swap_ids": "1,5", "mode": "admin"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "固定ペアはベンチ参加者と個別に入れ替えできません" in response.get_data(as_text=True)

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -59,7 +59,10 @@ def load_test_app(monkeypatch, tmp_path):
     sys.modules.pop("app", None)
     app_module = importlib.import_module("app")
 
-    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 6)]
+    participants = [
+        SimpleNamespace(id=player_id, card=f"♥{player_id}", name=f"player-{player_id}", games_played=0)
+        for player_id in range(1, 10)
+    ]
     participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
     monkeypatch.setattr(app_module, "Participant", participant_model)
     monkeypatch.setattr(
@@ -1157,3 +1160,150 @@ def test_admin_has_confirmed_when_shared_match_state_has_results(monkeypatch, tm
         "template": "index.html",
         "has_confirmed": True,
     }
+
+
+def write_draft(tmp_path, draft):
+    (tmp_path / "draft_state.json").write_text(json.dumps(draft), encoding="utf-8")
+
+
+def read_draft(tmp_path):
+    return json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+
+
+def test_swap_same_pair_toggles_fixed_pair_without_moving_players(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]})
+
+    response = app_module.app.test_client().post("/match/swap", data={"swap_ids": "2,1", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert response.status_code == 302
+    assert saved["matches"] == [[1, 2, 3, 4]]
+    assert saved["bench"] == [5]
+    assert saved["fixed_pairs"] == [[1, 2]]
+
+
+def test_swap_same_fixed_pair_unfixes_without_moving_players(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "fixed_pairs": [[1, 2]]})
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,2", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert saved["matches"] == [[1, 2, 3, 4]]
+    assert saved["fixed_pairs"] == []
+
+
+def test_swap_fixed_pair_member_with_other_pair_moves_whole_pairs(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4], [5, 6, 7, 8]], "bench": [9], "fixed_pairs": [[1, 2]]})
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,5", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert saved["matches"] == [[5, 6, 3, 4], [1, 2, 7, 8]]
+    assert saved["fixed_pairs"] == [[1, 2]]
+
+
+def test_swap_two_fixed_pairs_moves_pair_units_and_keeps_fixed(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4], [5, 6, 7, 8]], "bench": [9], "fixed_pairs": [[1, 2], [5, 6]]})
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,5", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert saved["matches"] == [[5, 6, 3, 4], [1, 2, 7, 8]]
+    assert saved["fixed_pairs"] == [[1, 2], [5, 6]]
+
+
+def test_swap_non_fixed_players_still_swaps_individuals(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]})
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,3", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert saved["matches"] == [[3, 2, 1, 4]]
+    assert saved["bench"] == [5]
+
+
+def test_swap_non_fixed_player_with_bench_still_swaps_individuals(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]})
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,5", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert saved["matches"] == [[5, 2, 3, 4]]
+    assert saved["bench"] == [1]
+
+
+def test_swap_fixed_pair_member_with_bench_is_rejected(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    original = {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "fixed_pairs": [[1, 2]]}
+    write_draft(tmp_path, original)
+
+    app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,5", "mode": "admin"})
+
+    assert read_draft(tmp_path)["matches"] == original["matches"]
+    assert read_draft(tmp_path)["bench"] == original["bench"]
+    assert read_draft(tmp_path)["fixed_pairs"] == original["fixed_pairs"]
+
+
+def test_swap_with_missing_fixed_pairs_field_keeps_working(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5]})
+
+    response = app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,3", "mode": "admin"})
+
+    assert response.status_code == 302
+    assert read_draft(tmp_path)["matches"] == [[3, 2, 1, 4]]
+
+
+def test_swap_ignores_broken_fixed_pairs_without_500(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {
+        "draft": True,
+        "matches": [[1, 2, 3, 4]],
+        "bench": [5],
+        "fixed_pairs": [[1, 99], [1, 3], [2, 2], "broken", [3]],
+    })
+
+    response = app_module.app.test_client().post("/match/swap", data={"swap_ids": "1,3", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert response.status_code == 302
+    assert saved["matches"] == [[3, 2, 1, 4]]
+    assert saved["fixed_pairs"] == []
+
+
+def test_confirm_match_clears_draft_fixed_pairs(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    _, state = configure_confirmation_state(
+        monkeypatch,
+        app_module,
+        {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    write_draft(tmp_path, {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "fixed_pairs": [[1, 2]]})
+
+    response = app_module.app.test_client().post("/match/confirm", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    assert state["matches"] == [[1, 2, 3, 4]]
+    assert not (tmp_path / "draft_state.json").exists()
+
+
+def test_new_match_generation_does_not_carry_fixed_pairs(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    write_draft(tmp_path, {"draft": True, "matches": [[9, 8, 7, 6]], "bench": [], "fixed_pairs": [[8, 9]]})
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 6)]
+    app_module.Participant = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(app_module, "generate_matches", lambda players, courts: ([players[:4]], players[4:]))
+
+    response = app_module.app.test_client().post("/match", data={"court_count": "1", "mode": "admin"})
+
+    saved = read_draft(tmp_path)
+    assert response.status_code == 302
+    assert saved["matches"] == [[1, 2, 3, 4]]
+    assert saved["bench"] == [5]
+    assert "fixed_pairs" not in saved

--- a/utils/draft_state.py
+++ b/utils/draft_state.py
@@ -12,7 +12,7 @@ def load_draft_state():
         return json.load(f)
 
 
-def save_draft_state(matches, bench, draft=True,court_count=None):
+def save_draft_state(matches, bench, draft=True, court_count=None, fixed_pairs=None):
     data = {
         "draft": draft,
         "timestamp": datetime.now().astimezone().isoformat(),
@@ -21,6 +21,8 @@ def save_draft_state(matches, bench, draft=True,court_count=None):
     }
     if court_count is not None:
         data["court_count"] = court_count
+    if fixed_pairs is not None:
+        data["fixed_pairs"] = fixed_pairs
 
     with open(DRAFT_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f)


### PR DESCRIPTION
### Motivation
- Enable administrators to temporarily lock a currently paired two-player unit while editing the draft so manual swaps treat that pair as a single unit for the current draft only. 
- Prepare the UI and draft state shape for future score-aware generation without persisting pair locks beyond the current draft lifecycle.

### Description
- Added helper functions in `app.py`: `get_current_pair`, `normalize_fixed_pairs`, `get_fixed_pair_for_player`, `same_current_pair`, and `swap_pair_positions` to identify, validate and manipulate pair-units in `match_ids`.
- Extended `save_draft_state` in `utils/draft_state.py` to optionally persist `fixed_pairs` and made `app` read/normalize `draft.get('fixed_pairs')` when rendering `/match/edit` and processing `/match/swap`.
- Enhanced `/match/swap` logic in `app.py` to: toggle fixed state when two players from the same current pair are selected, treat fixed pairs as atomic units when swapping with other pairs, reject attempts to swap a fixed-pair member with a bench-only player, normalize/ignore malformed `fixed_pairs`, and always persist `fixed_pairs` into the draft when applicable.
- Updated `/match/edit` rendering and `templates/match_edit.html` to mark fixed players with a CSS class and a small `固定` badge, and to avoid breaking when draft contains participant IDs not present in the DB.
- Added regression tests to `tests/test_match_draft.py` covering toggling, unfixing, pair-unit swaps, fixed-vs-fixed swaps, non-fixed swaps, bench swaps, bench rejection for fixed pairs, missing/broken `fixed_pairs`, confirm cleanup, and new-draft generation cleanup.

### Testing
- Ran full test suite with `pytest -q` and all tests passed successfully (including the new tests in `tests/test_match_draft.py`).
- Ran the match-draft focused tests (`pytest tests/test_match_draft.py`) during development and they passed after fixes for test fixtures and normalization behavior.
- Confirmed the implementation ignores malformed `fixed_pairs` without raising a 500 and that `fixed_pairs` is not retained after `/match/confirm` or when generating a new draft.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a460419cf748333a0ca16878b45ec26)