### PR TITLE
Add admin-only draft pair-score optimization (POST /match/optimize_pairs)

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,6 +175,199 @@ config = load_config()
 LEVEL_MAP = config.get("level_map", {})
 GENDER_WEIGHT = config.get("gender_weight", {})
 
+
+def normalize_fixed_pairs(raw_fixed_pairs, eligible_ids):
+    """Return valid, disjoint fixed pairs contained in eligible_ids."""
+    normalized = []
+    used = set()
+    if not isinstance(raw_fixed_pairs, list):
+        return normalized
+    for raw_pair in raw_fixed_pairs:
+        if not isinstance(raw_pair, (list, tuple)) or len(raw_pair) != 2:
+            continue
+        try:
+            left, right = int(raw_pair[0]), int(raw_pair[1])
+        except (TypeError, ValueError):
+            continue
+        if left == right or left not in eligible_ids or right not in eligible_ids:
+            continue
+        pair = tuple(sorted((left, right)))
+        if pair[0] in used or pair[1] in used or pair in normalized:
+            continue
+        normalized.append(pair)
+        used.update(pair)
+    return normalized
+
+
+def collect_pair_history_counts():
+    """Count historical doubles pairs, treating player order as irrelevant."""
+    counts = {}
+    for history in MatchHistory.query.all():
+        for left, right in (
+            (history.team1_player1_id, history.team1_player2_id),
+            (history.team2_player1_id, history.team2_player2_id),
+        ):
+            if left is None or right is None or left == right:
+                continue
+            pair = tuple(sorted((left, right)))
+            counts[pair] = counts.get(pair, 0) + 1
+    return counts
+
+
+def build_pair_scores(participants_by_id):
+    config = load_config()
+    win_stats = calculate_participant_win_stats()
+    scores = {}
+    for participant_id, participant in participants_by_id.items():
+        score_data = calculate_pair_score(
+            [participant],
+            config["level_map"],
+            config["gender_weight"],
+            win_stats,
+        )
+        scores[participant_id] = score_data["total_score"]
+    return scores
+
+
+def greedy_pairs_for_optimization(singles, history_counts, player_scores):
+    remaining = list(singles)
+    pairs = []
+    while len(remaining) >= 2:
+        left = remaining.pop(0)
+        best_index = min(
+            range(len(remaining)),
+            key=lambda index: (
+                history_counts.get(tuple(sorted((left, remaining[index]))), 0),
+                abs(player_scores.get(left, 0) - player_scores.get(remaining[index], 0)),
+                remaining[index],
+            ),
+        )
+        right = remaining.pop(best_index)
+        pairs.append((left, right))
+    return pairs, remaining
+
+
+def pairing_history_cost(pairs, history_counts):
+    return sum(history_counts.get(tuple(sorted(pair)), 0) for pair in pairs)
+
+
+def pairing_matchup_cost(pairs, player_scores):
+    arranged, leftovers = arrange_pairs_by_close_score(pairs, player_scores)
+    if leftovers:
+        return float('inf')
+    return sum(
+        abs(
+            player_scores.get(group[0], 0)
+            + player_scores.get(group[1], 0)
+            - player_scores.get(group[2], 0)
+            - player_scores.get(group[3], 0)
+        )
+        for group in arranged
+    )
+
+
+def exhaustive_pairs_for_optimization(singles, fixed_pairs, history_counts, player_scores):
+    best_pairs = None
+    best_key = None
+
+    def search(remaining, built_pairs):
+        nonlocal best_pairs, best_key
+        if not remaining:
+            candidate = list(fixed_pairs) + built_pairs
+            if len(candidate) % 2 != 0:
+                return
+            key = (
+                pairing_history_cost(built_pairs, history_counts),
+                pairing_matchup_cost(candidate, player_scores),
+                sorted(tuple(sorted(pair)) for pair in built_pairs),
+            )
+            if best_key is None or key < best_key:
+                best_key = key
+                best_pairs = candidate
+            return
+
+        left = remaining[0]
+        rest = remaining[1:]
+        for index, right in enumerate(rest):
+            next_remaining = rest[:index] + rest[index + 1:]
+            search(next_remaining, built_pairs + [(left, right)])
+
+    search(list(singles), [])
+    return best_pairs
+
+
+def make_pairs_for_optimization(player_ids, fixed_pairs, history_counts, player_scores):
+    fixed_players = {pid for pair in fixed_pairs for pid in pair}
+    singles = [pid for pid in player_ids if pid not in fixed_players]
+
+    if len(singles) % 2 != 0:
+        return list(fixed_pairs), singles[-1:]
+
+    if len(singles) <= 12:
+        pairs = exhaustive_pairs_for_optimization(singles, fixed_pairs, history_counts, player_scores)
+        if pairs is not None:
+            return pairs, []
+
+    greedy_pairs, leftovers = greedy_pairs_for_optimization(singles, history_counts, player_scores)
+    return list(fixed_pairs) + greedy_pairs, leftovers
+
+
+def arrange_pairs_by_close_score(pairs, player_scores):
+    scored_pairs = [
+        (pair, player_scores.get(pair[0], 0) + player_scores.get(pair[1], 0))
+        for pair in pairs
+    ]
+    scored_pairs.sort(key=lambda item: item[1])
+    arranged = []
+    while len(scored_pairs) >= 2:
+        first_pair, _ = scored_pairs.pop(0)
+        best_index = min(
+            range(len(scored_pairs)),
+            key=lambda index: abs(
+                (player_scores.get(first_pair[0], 0) + player_scores.get(first_pair[1], 0))
+                - scored_pairs[index][1]
+            ),
+        )
+        second_pair, _ = scored_pairs.pop(best_index)
+        arranged.append([first_pair[0], first_pair[1], second_pair[0], second_pair[1]])
+    leftovers = [pid for pair, _score in scored_pairs for pid in pair]
+    return arranged, leftovers
+
+
+def optimize_draft_matches_by_pair_score(draft):
+    matches = draft.get('matches')
+    bench = draft.get('bench')
+    if not isinstance(matches, list) or not isinstance(bench, list) or not matches:
+        return None, [], '調整できる編集中の組み合わせがありません'
+    if not all(isinstance(group, list) and len(group) == 4 for group in matches):
+        return None, [], '編集中の組み合わせが不正なため調整しませんでした'
+
+    player_ids = []
+    try:
+        for group in matches:
+            player_ids.extend(int(pid) for pid in group)
+    except (TypeError, ValueError):
+        return None, [], '編集中の組み合わせに不正な参加者IDが含まれるため調整しませんでした'
+
+    if len(player_ids) != len(set(player_ids)) or len(player_ids) % 4 != 0:
+        return None, [], '編集中の組み合わせが不正なため調整しませんでした'
+
+    participants_by_id = {p.id: p for p in Participant.query.filter(Participant.id.in_(player_ids)).all()}
+    if set(player_ids) - set(participants_by_id):
+        return None, [], '編集中の組み合わせに存在しない参加者が含まれるため調整しませんでした'
+
+    fixed_pairs = normalize_fixed_pairs(draft.get('fixed_pairs'), set(player_ids))
+    history_counts = collect_pair_history_counts()
+    player_scores = build_pair_scores(participants_by_id)
+    pairs, leftover_players = make_pairs_for_optimization(player_ids, fixed_pairs, history_counts, player_scores)
+    if leftover_players or len(pairs) % 2 != 0:
+        return None, fixed_pairs, 'ペア数が不正なため調整しませんでした'
+
+    optimized_matches, leftovers = arrange_pairs_by_close_score(pairs, player_scores)
+    if leftovers:
+        return None, fixed_pairs, '対戦を組み切れなかったため調整しませんでした'
+    return optimized_matches, fixed_pairs, None
+
 def get_match_count():
     state = load_match_state()
     count = state['match_count']
@@ -543,9 +736,43 @@ def swap_players():
         match_ids,
         new_bench_ids,
         court_count=draft.get('court_count'),
+        fixed_pairs=normalize_fixed_pairs(draft.get('fixed_pairs'), {pid for group in match_ids for pid in group}),
     )
 
     return redirect(url_for('edit_matches', mode=mode))
+
+
+@app.route('/match/optimize_pairs', methods=['POST'])
+def optimize_pairs():
+    mode = request.form.get('mode', 'admin')
+    if mode != 'admin':
+        return redirect(url_for('match_draft', mode=mode))
+
+    draft = get_active_draft()
+    if draft is None:
+        flash('調整できる編集中の組み合わせがありません')
+        return redirect(url_for('match_form'))
+
+    optimized_matches, fixed_pairs, error_message = optimize_draft_matches_by_pair_score(draft)
+    if error_message:
+        if fixed_pairs:
+            save_draft_state(
+                draft.get('matches', []),
+                draft.get('bench', []),
+                court_count=draft.get('court_count'),
+                fixed_pairs=[list(pair) for pair in fixed_pairs],
+            )
+        flash(error_message)
+        return redirect(url_for('edit_matches', mode='admin'))
+
+    save_draft_state(
+        optimized_matches,
+        draft.get('bench', []),
+        court_count=draft.get('court_count'),
+        fixed_pairs=[list(pair) for pair in fixed_pairs],
+    )
+    flash('ペアスコアが近い対戦になるように編集中の組み合わせを調整しました')
+    return redirect(url_for('edit_matches', mode='admin'))
 
 def has_valid_draft(matches, bench):
     return (

--- a/templates/match_edit.html
+++ b/templates/match_edit.html
@@ -125,6 +125,13 @@
     </ul>
 </form>
 
+{% if matches and mode == 'admin' %}
+<form action="{{ url_for('optimize_pairs') }}" method="post">
+    <input type="hidden" name="mode" value="{{ mode }}">
+    <button type="submit" class="btn btn-secondary">スコアが近いペアで組み直す</button>
+</form>
+{% endif %}
+
 <form action="{{ url_for('confirm_match') }}" method="post">
     <input type="hidden" name="mode" value="{{ mode }}">
     <button type="submit" class="btn">この組み合わせを確定する</button>

--- a/tests/test_match_draft.py
+++ b/tests/test_match_draft.py
@@ -1157,3 +1157,201 @@ def test_admin_has_confirmed_when_shared_match_state_has_results(monkeypatch, tm
         "template": "index.html",
         "has_confirmed": True,
     }
+
+
+def load_real_db_app(monkeypatch, tmp_path):
+    config = {
+        "level_map": {"A": 10, "B": 20, "C": 30, "D": 40},
+        "gender_weight": {"M": 1.0, "F": 1.0},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    app_module.app.config["TESTING"] = True
+    return app_module
+
+
+def add_score_participants(app_module):
+    app_module.BenchHistory.query.delete()
+    app_module.MatchHistory.query.delete()
+    app_module.MatchRound.query.delete()
+    app_module.Participant.query.delete()
+    app_module.db.session.commit()
+    levels = ["A", "B", "C", "D", "A", "B", "C", "D", "A"]
+    participants = []
+    for player_id, level in enumerate(levels, start=1):
+        participant = app_module.Participant(
+            id=player_id,
+            name=f"P{player_id}",
+            gender="M",
+            level=level,
+            weight=1.0,
+            games_played=0,
+            active=True,
+            card=f"♥{player_id}",
+        )
+        participants.append(participant)
+        app_module.db.session.add(participant)
+    app_module.db.session.commit()
+    return participants
+
+
+def test_match_edit_shows_optimize_button_for_admin_draft(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "court_count": 1}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().get("/match/edit?mode=admin")
+
+    assert response.status_code == 200
+    assert "スコアが近いペアで組み直す" in response.get_data(as_text=True)
+    assert "/match/optimize_pairs" in response.get_data(as_text=True)
+
+
+def test_viewer_does_not_show_optimize_button(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "court_count": 1}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().get("/match/edit?mode=viewer", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert "スコアが近いペアで組み直す" not in response.get_data(as_text=True)
+    assert "/match/optimize_pairs" not in response.get_data(as_text=True)
+
+
+def test_optimize_pairs_updates_matches_preserves_bench_and_fixed_pair(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+        match_round = app_module.MatchRound(round_number=1)
+        app_module.db.session.add(match_round)
+        app_module.db.session.flush()
+        app_module.db.session.add(app_module.MatchHistory(
+            round_id=match_round.id,
+            court_number=1,
+            team1_player1_id=3,
+            team1_player2_id=4,
+            team2_player1_id=5,
+            team2_player2_id=6,
+        ))
+        app_module.db.session.commit()
+    original = {
+        "draft": True,
+        "matches": [[1, 2, 3, 4], [5, 6, 7, 8]],
+        "bench": [9],
+        "court_count": 2,
+        "fixed_pairs": [[1, 2], [999, 1000], [3]],
+    }
+    (tmp_path / "draft_state.json").write_text(json.dumps(original), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/optimize_pairs", data={"mode": "admin"})
+
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    saved_pairs = {tuple(sorted(group[index:index + 2])) for group in saved["matches"] for index in (0, 2)}
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/match/edit?mode=admin")
+    assert saved["matches"] != original["matches"]
+    assert saved["bench"] == [9]
+    assert saved["court_count"] == 2
+    assert saved["fixed_pairs"] == [[1, 2]]
+    assert (1, 2) in saved_pairs
+    assert (3, 4) not in saved_pairs
+    assert (5, 6) not in saved_pairs
+
+
+def test_optimize_pairs_matches_close_pair_scores(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 4, 2, 3], [5, 8, 6, 7]], "bench": [9], "court_count": 2}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().post("/match/optimize_pairs", data={"mode": "admin"})
+
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    score_by_id = {1: 10, 2: 20, 3: 30, 4: 40, 5: 10, 6: 20, 7: 30, 8: 40}
+    differences = []
+    for group in saved["matches"]:
+        left = score_by_id[group[0]] + score_by_id[group[1]]
+        right = score_by_id[group[2]] + score_by_id[group[3]]
+        differences.append(abs(left - right))
+    assert response.status_code == 302
+    assert max(differences) == 0
+
+
+def test_optimize_pairs_without_history_does_not_error(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    original = {"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "court_count": 1}
+    (tmp_path / "draft_state.json").write_text(json.dumps(original), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/optimize_pairs", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert sorted(pid for group in saved["matches"] for pid in group) == [1, 2, 3, 4]
+
+
+def test_optimize_pairs_with_broken_fixed_pairs_does_not_500(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    (tmp_path / "draft_state.json").write_text(
+        json.dumps({"draft": True, "matches": [[1, 2, 3, 4]], "bench": [5], "fixed_pairs": [[1], [2, 999], [3, 3], "bad"]}),
+        encoding="utf-8",
+    )
+
+    response = app_module.app.test_client().post("/match/optimize_pairs", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert saved["fixed_pairs"] == []
+
+
+def test_optimize_pairs_with_invalid_matches_does_not_500_or_change_draft(monkeypatch, tmp_path):
+    app_module = load_real_db_app(monkeypatch, tmp_path)
+    with app_module.app.app_context():
+        add_score_participants(app_module)
+    original = {"draft": True, "matches": [[1, 2, 3]], "bench": [5], "fixed_pairs": [[1, 2]]}
+    (tmp_path / "draft_state.json").write_text(json.dumps(original), encoding="utf-8")
+
+    response = app_module.app.test_client().post("/match/optimize_pairs", data={"mode": "admin"})
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert saved == original
+
+
+def test_normal_match_generation_does_not_auto_optimize_by_pair_score(monkeypatch, tmp_path):
+    app_module = load_test_app(monkeypatch, tmp_path)
+    participants = [SimpleNamespace(id=player_id) for player_id in range(1, 9)]
+    participant_model = SimpleNamespace(query=SimpleNamespace(all=lambda: participants))
+    monkeypatch.setattr(app_module, "Participant", participant_model)
+    monkeypatch.setattr(app_module, "generate_matches", lambda players, courts: ([players[:4], players[4:]], []))
+    monkeypatch.setattr(
+        app_module,
+        "load_match_state",
+        lambda: {"match_active": False, "matches": [], "bench": [], "match_count": 0},
+    )
+    called = []
+    monkeypatch.setattr(app_module, "optimize_draft_matches_by_pair_score", lambda draft: called.append(draft))
+
+    response = app_module.app.test_client().post("/match", data={"court_count": "2", "mode": "admin"})
+
+    saved = json.loads((tmp_path / "draft_state.json").read_text(encoding="utf-8"))
+    assert response.status_code == 302
+    assert saved["matches"] == [[1, 2, 3, 4], [5, 6, 7, 8]]
+    assert called == []

--- a/utils/draft_state.py
+++ b/utils/draft_state.py
@@ -12,7 +12,7 @@ def load_draft_state():
         return json.load(f)
 
 
-def save_draft_state(matches, bench, draft=True,court_count=None):
+def save_draft_state(matches, bench, draft=True, court_count=None, fixed_pairs=None):
     data = {
         "draft": draft,
         "timestamp": datetime.now().astimezone().isoformat(),
@@ -21,6 +21,8 @@ def save_draft_state(matches, bench, draft=True,court_count=None):
     }
     if court_count is not None:
         data["court_count"] = court_count
+    if fixed_pairs is not None:
+        data["fixed_pairs"] = fixed_pairs
 
     with open(DRAFT_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f)


### PR DESCRIPTION
### Motivation
- Provide an admin-invoked adjustment on `/match/edit` to rebalance currently edited draft matches by pair scores without changing normal generation behavior. 
- Preserve any existing fixed pairs and bench state while allowing re-pairing of non-fixed players. 
- Prefer pairings that avoid frequent historical pairings and try to match pairs with similar pair-scores for fairer matchups.

### Description
- Add pair-optimization helpers to `app.py` including `normalize_fixed_pairs`, `collect_pair_history_counts`, `build_pair_scores`, pairing algorithms (`greedy_pairs_for_optimization`, `exhaustive_pairs_for_optimization`, `make_pairs_for_optimization`, `arrange_pairs_by_close_score`) and the main `optimize_draft_matches_by_pair_score` evaluator. 
- Add a new admin-only POST route `POST /match/optimize_pairs` (`optimize_pairs`) that reads the active draft, runs the optimization, saves updated `matches` (keeping `bench` and `court_count`) and preserves normalized `fixed_pairs` to the draft, flashes results, and redirects back to `/match/edit`. 
- Extend draft persistence in `utils/draft_state.py` by adding optional `fixed_pairs` to `save_draft_state` and ensure existing swap behavior preserves normalized `fixed_pairs`. 
- Add an admin-only button to `templates/match_edit.html` (shown only when an editable draft exists and `mode == 'admin'`) that posts to the new optimization route, and add regression tests in `tests/test_match_draft.py` to cover visibility, behavior, edge cases and that normal generation does not auto-optimize.

### Testing
- Ran the full test suite with `pytest` and all tests passed (`161 passed`).
- Added targeted tests in `tests/test_match_draft.py` that assert the optimize button visibility, admin-only rendering, `draft_state.json` updates, bench preservation, `fixed_pairs` normalization/preservation, avoidance of historical pairs when possible, pairing closeness by score, and robust behavior for broken/invalid drafts. 
- Ensured normal match generation (`/match` flow) does not invoke the optimization automatically and existing swap/confirm flows continue to work according to tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4613637aa08333bb935cc77563dc01)