### PR TITLE
Add current MatchSession management

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ from utils.pair_optimizer import (
 )
 from utils.stats import calculate_participant_win_stats
 from utils.reset import reset_match_state
+from utils.match_session import ensure_current_match_session
 from routes.api import api_bp
 
 app = Flask(__name__, instance_relative_config=True)
@@ -441,6 +442,9 @@ def match_form():
         # 最初のアクセス or リセット後はフォーム表示
         return render_template('match_form.html', mode=mode)
 
+    ensure_current_match_session()
+    state = load_match_state()
+
     participants = Participant.query.all()
     matches, bench = generate_matches(participants, court_count)
 
@@ -734,6 +738,8 @@ def confirm_match():
         flash(INVALID_DRAFT_MESSAGE)
         return redirect(url_for('match_form'))
     match_ids, bench_ids = editable_parts
+
+    ensure_current_match_session()
 
     # 組み合わせ回数カウントアップ
     state = load_match_state()

--- a/app.py
+++ b/app.py
@@ -1011,7 +1011,7 @@ def reset_db():
         return redirect(url_for('admin_settings'))
 
     # 先にマッチ状態をリセット
-    reset_match_state()
+    reset_match_state(create_new_session=False)
     db.create_all()
     # その後で履歴、通知関連データ、参加者データをすべて削除
     # Bulk delete does not trigger SQLAlchemy relationship cascades, so delete

--- a/tests/test_flash_messages.py
+++ b/tests/test_flash_messages.py
@@ -41,7 +41,7 @@ def test_register_validation_flash_is_rendered(monkeypatch, tmp_path):
 
 def test_reset_match_flash_is_rendered_on_match_form(monkeypatch, tmp_path):
     app_module = import_app(monkeypatch, tmp_path)
-    monkeypatch.setattr(app_module, "reset_match_state", lambda: None)
+    monkeypatch.setattr(app_module, "reset_match_state", lambda *args, **kwargs: None)
     client = app_module.app.test_client()
 
     response = client.post("/reset_match", follow_redirects=True)
@@ -74,7 +74,7 @@ def test_admin_settings_save_flash_is_rendered(monkeypatch, tmp_path):
 
 def test_reset_db_flash_is_rendered_on_admin_settings(monkeypatch, tmp_path):
     app_module = import_app(monkeypatch, tmp_path)
-    monkeypatch.setattr(app_module, "reset_match_state", lambda: None)
+    monkeypatch.setattr(app_module, "reset_match_state", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         app_module,
         "Participant",

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from models import utc_now
+from utils.match_session import get_current_match_session, get_current_session_id
 
 
 def load_history_test_app(monkeypatch, tmp_path):
@@ -203,6 +204,29 @@ def test_reset_db_clears_notification_tables_and_participants(monkeypatch, tmp_p
         assert app_module.LineAccount.query.count() == 0
         assert app_module.MatchSession.query.count() == 0
         assert app_module.Participant.query.count() == 0
+
+
+def test_reset_db_clears_current_session_without_creating_stale_session(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        _participants, old_session = add_notification_fixture(app_module)
+        app_module.save_match_state_full(
+            True,
+            [[1, 2, 1, 2]],
+            [],
+            1,
+            session_id=old_session.id,
+        )
+
+        response = app_module.app.test_client().post("/admin/reset_db")
+
+        state = app_module.load_match_state()
+        assert response.status_code == 302
+        assert app_module.MatchSession.query.count() == 0
+        assert "session_id" not in state
+        assert get_current_session_id() is None
+        assert get_current_match_session() is None
 
 
 def test_ensure_database_tables_adds_missing_history_tables_for_existing_db(monkeypatch, tmp_path):

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -101,7 +101,9 @@ def test_confirm_match_persists_round_matches_bench_and_preserves_state_flow(mon
 
     with app_module.app.app_context():
         add_participants(app_module, 9)
-        response = app_module.app.test_client().post("/match/confirm", data={"mode": "admin"})
+        response = app_module.app.test_client().post(
+            "/match/confirm", data={"mode": "admin"}
+        )
 
         assert response.status_code == 302
         assert response.headers["Location"].endswith("/match/result?mode=admin")
@@ -228,6 +230,66 @@ def test_reset_db_clears_current_session_without_creating_stale_session(monkeypa
         assert get_current_session_id() is None
         assert get_current_match_session() is None
 
+
+def test_match_generation_creates_current_session_without_reset(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        response = app_module.app.test_client().post(
+            "/match", data={"court_count": "1", "mode": "admin"}
+        )
+
+        state = app_module.load_match_state()
+        session_id = state.get("session_id")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/match/edit?mode=admin")
+        assert session_id is not None
+        assert app_module.MatchSession.query.count() == 1
+        current_session = app_module.db.session.get(app_module.MatchSession, session_id)
+        assert current_session is not None
+        assert current_session.status == "draft"
+        assert get_current_session_id() == session_id
+        assert get_current_match_session().id == session_id
+
+
+def test_confirm_match_creates_current_session_when_state_has_no_session_id(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    matches = [[1, 2, 3, 4]]
+    bench = [5]
+    write_draft(tmp_path, matches, bench, court_count=1)
+    (tmp_path / "match_state.json").write_text(
+        json.dumps(
+            {
+                "match_active": False,
+                "match_count": 0,
+                "matches": [],
+                "bench": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with app_module.app.app_context():
+        add_participants(app_module, 5)
+        response = app_module.app.test_client().post(
+            "/match/confirm", data={"mode": "admin"}
+        )
+
+        state = app_module.load_match_state()
+        session_id = state.get("session_id")
+        assert response.status_code == 302
+        assert session_id is not None
+        assert app_module.MatchSession.query.count() == 1
+        current_session = app_module.db.session.get(app_module.MatchSession, session_id)
+        assert current_session is not None
+        assert current_session.status == "draft"
+        assert state["match_active"] is True
+        assert state["match_count"] == 1
+        assert state["matches"] == matches
+        assert state["bench"] == bench
+        assert get_current_session_id() == session_id
+        assert get_current_match_session().id == session_id
 
 def test_ensure_database_tables_adds_missing_history_tables_for_existing_db(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)

--- a/tests/test_match_session.py
+++ b/tests/test_match_session.py
@@ -1,0 +1,138 @@
+import json
+
+from flask import Flask
+
+from models import db, MatchSession, NotificationSubscription, Participant
+from utils.match_session import (
+    close_current_match_session,
+    ensure_current_match_session,
+    get_current_match_session,
+)
+from utils.match_state import load_match_state
+from utils.reset import reset_match_state
+
+
+import pytest
+
+
+@pytest.fixture
+def app_context(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'test.db'}",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def write_match_state(tmp_path, state):
+    (tmp_path / "match_state.json").write_text(
+        json.dumps(state), encoding="utf-8"
+    )
+
+
+def test_ensure_current_match_session_creates_session_and_saves_id(app_context, tmp_path):
+    session = ensure_current_match_session()
+
+    assert session.id is not None
+    assert session.status == "draft"
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert state["session_id"] == session.id
+    assert state["match_active"] is False
+    assert state["matches"] == []
+
+
+def test_ensure_current_match_session_reuses_existing_session(app_context, tmp_path):
+    existing_session = MatchSession(status="draft")
+    db.session.add(existing_session)
+    db.session.commit()
+    write_match_state(
+        tmp_path,
+        {
+            "session_id": existing_session.id,
+            "match_active": True,
+            "match_count": 2,
+            "matches": [[1, 2, 3, 4]],
+            "bench": [5],
+        },
+    )
+
+    session = ensure_current_match_session()
+
+    assert session.id == existing_session.id
+    assert MatchSession.query.count() == 1
+
+
+def test_get_current_match_session_returns_session_for_state_id(app_context, tmp_path):
+    existing_session = MatchSession(status="confirmed", match_count=1)
+    db.session.add(existing_session)
+    db.session.commit()
+    write_match_state(tmp_path, {"session_id": existing_session.id})
+
+    assert get_current_match_session().id == existing_session.id
+
+
+def test_get_current_match_session_returns_none_without_session_id(app_context, tmp_path):
+    write_match_state(tmp_path, {"match_active": False, "matches": [], "bench": []})
+
+    assert get_current_match_session() is None
+
+
+def test_get_current_match_session_returns_none_for_missing_db_session(app_context, tmp_path):
+    write_match_state(tmp_path, {"session_id": 999})
+
+    assert get_current_match_session() is None
+
+
+def test_reset_match_closes_old_session_and_starts_new_session(app_context, tmp_path):
+    player = Participant(
+        name="player-1",
+        gender="male",
+        level="beginner",
+        weight=1.0,
+        card="C1",
+        games_played=3,
+    )
+    old_session = MatchSession(status="draft", match_count=1)
+    db.session.add_all([player, old_session])
+    db.session.flush()
+    subscription = NotificationSubscription(
+        session_id=old_session.id,
+        participant_id=player.id,
+        channel="line",
+    )
+    db.session.add(subscription)
+    db.session.commit()
+    write_match_state(
+        tmp_path,
+        {
+            "session_id": old_session.id,
+            "match_active": True,
+            "match_count": 1,
+            "matches": [[player.id, player.id, player.id, player.id]],
+            "bench": [],
+        },
+    )
+
+    reset_match_state()
+
+    db.session.refresh(old_session)
+    new_session_id = load_match_state()["session_id"]
+    new_session = db.session.get(MatchSession, new_session_id)
+    assert old_session.status == "closed"
+    assert new_session.id != old_session.id
+    assert new_session.status == "draft"
+    assert player.games_played == 0
+    assert NotificationSubscription.query.count() == 1
+    assert NotificationSubscription.query.one().session_id == old_session.id
+
+
+def test_close_current_match_session_noops_without_current_session(app_context):
+    assert close_current_match_session() is None

--- a/tests/test_match_state.py
+++ b/tests/test_match_state.py
@@ -71,3 +71,25 @@ def test_save_match_state_full_ignores_invalid_court_count(monkeypatch, tmp_path
 
     state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
     assert "court_count" not in state
+
+
+def test_save_match_state_full_preserves_existing_session_id(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "match_state.json").write_text(
+        json.dumps(
+            {
+                "session_id": 12,
+                "match_active": True,
+                "match_count": 1,
+                "matches": [[1, 2, 3, 4]],
+                "bench": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    save_match_state_full(False, [], [], 0)
+
+    state = json.loads((tmp_path / "match_state.json").read_text(encoding="utf-8"))
+    assert state["session_id"] == 12
+    assert state["match_active"] is False

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -22,7 +22,7 @@ def test_reset_clears_shared_match_state_without_managing_confirmed_session_keys
     monkeypatch.setattr(
         reset_module,
         "save_match_state_full",
-        lambda *args: saved_states.append(args),
+        lambda *args, **kwargs: saved_states.append((args, kwargs)),
     )
     monkeypatch.setattr(
         reset_module,
@@ -35,6 +35,8 @@ def test_reset_clears_shared_match_state_without_managing_confirmed_session_keys
         SimpleNamespace(commit=lambda: None),
     )
     monkeypatch.setattr(reset_module, "clear_draft_state", lambda: None)
+    monkeypatch.setattr(reset_module, "close_current_match_session", lambda: None)
+    monkeypatch.setattr(reset_module, "ensure_current_match_session", lambda: None)
 
     with app.test_request_context():
         session["last_confirmed_matches"] = [[9]]
@@ -42,7 +44,7 @@ def test_reset_clears_shared_match_state_without_managing_confirmed_session_keys
 
         reset_module.reset_match_state()
 
-        assert saved_states == [(False, [], [], 0)]
+        assert saved_states == [((False, [], [], 0), {"session_id": None})]
         assert [participant.games_played for participant in participants] == [0, 0]
         assert session["last_confirmed_matches"] == [[9]]
         assert session["last_confirmed_bench"] == [10]
@@ -69,6 +71,8 @@ def test_reset_match_state_does_not_preserve_court_count(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(reset_module.db, "session", SimpleNamespace(commit=lambda: None))
     monkeypatch.setattr(reset_module, "clear_draft_state", lambda: None)
+    monkeypatch.setattr(reset_module, "close_current_match_session", lambda: None)
+    monkeypatch.setattr(reset_module, "ensure_current_match_session", lambda: None)
 
     reset_module.reset_match_state()
 

--- a/utils/match_session.py
+++ b/utils/match_session.py
@@ -1,0 +1,48 @@
+from models import MatchSession, db
+from utils.match_state import load_match_state, save_match_state
+
+
+def get_current_session_id():
+    """Return the current match_state.json session_id, or None if absent/invalid."""
+    session_id = load_match_state().get("session_id")
+    if session_id is None:
+        return None
+    try:
+        return int(session_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_current_match_session():
+    """Load the current MatchSession referenced by match_state.json."""
+    session_id = get_current_session_id()
+    if session_id is None:
+        return None
+    return db.session.get(MatchSession, session_id)
+
+
+def ensure_current_match_session():
+    """Return the current MatchSession, creating and storing one when needed."""
+    current_session = get_current_match_session()
+    if current_session is not None:
+        return current_session
+
+    current_session = MatchSession(status="draft")
+    db.session.add(current_session)
+    db.session.commit()
+
+    state = load_match_state()
+    state["session_id"] = current_session.id
+    save_match_state(state)
+    return current_session
+
+
+def close_current_match_session():
+    """Mark the current MatchSession closed when one exists."""
+    current_session = get_current_match_session()
+    if current_session is None:
+        return None
+    if current_session.status != "closed":
+        current_session.status = "closed"
+    db.session.commit()
+    return current_session

--- a/utils/match_state.py
+++ b/utils/match_state.py
@@ -24,7 +24,11 @@ def save_match_state(state):
         json.dump(state, f, ensure_ascii=False, indent=2)
 
 
-def save_match_state_full(match_active, matches, bench, match_count, *, court_count=None):
+_UNSET = object()
+
+
+def save_match_state_full(match_active, matches, bench, match_count, *, court_count=None, session_id=_UNSET):
+    existing_state = load_match_state()
     state = {
         "match_active": match_active,
         "match_count": match_count,
@@ -34,4 +38,8 @@ def save_match_state_full(match_active, matches, bench, match_count, *, court_co
     }
     if isinstance(court_count, int) and court_count > 0:
         state["court_count"] = court_count
+    if session_id is _UNSET:
+        session_id = existing_state.get("session_id")
+    if session_id is not None:
+        state["session_id"] = session_id
     save_match_state(state)

--- a/utils/reset.py
+++ b/utils/reset.py
@@ -1,15 +1,24 @@
 from models import Participant, db
 from utils.match_state import load_match_state, save_match_state_full
 from utils.draft_state import clear_draft_state
+from utils.match_session import close_current_match_session, ensure_current_match_session
 
 def reset_match_state():
+    close_current_match_session()
+
     # JSONファイルのリセット
     state = load_match_state()
     state['match_active'] = False
     state['match_count'] = 0
     state['matches'] = []
     state['bench'] = []
-    save_match_state_full(state.get('match_active', False), state.get('matches', []), state.get('bench', []), state.get('match_count', 0))
+    save_match_state_full(
+        state.get('match_active', False),
+        state.get('matches', []),
+        state.get('bench', []),
+        state.get('match_count', 0),
+        session_id=None,
+    )
 
     # 試合回数のリセット（※reset_dbで全削除するなら不要だが共通化）
     participants = Participant.query.all()
@@ -19,3 +28,5 @@ def reset_match_state():
 
     # 下書き状態の削除
     clear_draft_state()
+
+    ensure_current_match_session()

--- a/utils/reset.py
+++ b/utils/reset.py
@@ -3,7 +3,7 @@ from utils.match_state import load_match_state, save_match_state_full
 from utils.draft_state import clear_draft_state
 from utils.match_session import close_current_match_session, ensure_current_match_session
 
-def reset_match_state():
+def reset_match_state(create_new_session=True):
     close_current_match_session()
 
     # JSONファイルのリセット
@@ -29,4 +29,5 @@ def reset_match_state():
     # 下書き状態の削除
     clear_draft_state()
 
-    ensure_current_match_session()
+    if create_new_session:
+        ensure_current_match_session()


### PR DESCRIPTION
### Motivation
- Manage LINE notification registration scoped to the current match session so subscriptions are tied to a `MatchSession` instead of being global across resets.
- On `reset_match` start a new `MatchSession` to avoid carrying old subscriptions into the next practice while keeping old records intact.
- Provide small helpers to read, ensure, and close the current session without changing other match-state storage semantics.

### Description
- Add `utils/match_session.py` with `get_current_session_id()`, `get_current_match_session()`, `ensure_current_match_session()`, and `close_current_match_session()` to resolve and manage the current `MatchSession` referenced by `match_state.json`.
- Update `save_match_state_full()` in `utils/match_state.py` to preserve an existing `session_id` by default and accept an explicit `session_id` parameter so normal saves do not drop the current session id.
- Update `reset_match_state()` in `utils/reset.py` to `close_current_match_session()`, clear the `session_id` in `match_state.json` (by calling `save_match_state_full(..., session_id=None)`), reset players and draft state, and then `ensure_current_match_session()` to create a fresh draft session.
- Add `tests/test_match_session.py` and update `tests/test_match_state.py` and `tests/test_reset.py` to cover creation/reuse of current session, missing/stale `session_id` handling, reset rollover behavior, and ensuring old `NotificationSubscription` records remain attached to the old session.

### Testing
- Ran `pytest` including targeted runs of `tests/test_match_session.py`, `tests/test_reset.py`, and `tests/test_match_state.py`, and all tests passed.
- Full test suite result: `207 passed`.
- Changed files tested: `utils/match_session.py`, `utils/match_state.py`, `utils/reset.py`, `tests/test_match_session.py`, `tests/test_match_state.py`, and `tests/test_reset.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c478c89588333990a2dbf33f647db)