### PR TITLE
Add participant LINE notification subscription UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,9 @@ import json
 import io
 import logging
 import re
-from datetime import datetime, timezone
+import secrets
+import string
+from datetime import datetime, timedelta, timezone
 from io import TextIOWrapper
 from flask import Flask, render_template, request, redirect, url_for, abort
 from models import (
@@ -18,6 +20,7 @@ from models import (
     NotificationDeliveryLog,
     NotificationSubscription,
     Participant,
+    utc_now,
 )
 # from flask_sqlalchemy import SQLAlchemy
 from flask import flash
@@ -323,10 +326,76 @@ def register():
         db.session.add(p)
         db.session.commit()
 
-        return redirect(url_for('thanks', mode=mode))
+        return redirect(url_for('thanks', mode=mode, card=card))
 
     card = request.args.get('card')
     return render_template('register.html', card=card, mode=mode)
+
+
+def get_participant_by_card_or_404(card):
+    participant = Participant.query.filter_by(card=card).first()
+    if participant is None:
+        abort(404)
+    return participant
+
+
+def get_active_line_account(participant):
+    account = participant.line_account
+    if account is not None and account.active:
+        return account
+    return None
+
+
+def get_line_notification_subscription(participant_id, session_id):
+    return NotificationSubscription.query.filter_by(
+        session_id=session_id,
+        participant_id=participant_id,
+        channel="line",
+    ).first()
+
+
+def get_line_notification_status(participant, current_session):
+    has_active_line_account = get_active_line_account(participant) is not None
+    current_subscription = get_line_notification_subscription(
+        participant.id, current_session.id
+    )
+    current_subscription_active = (
+        current_subscription is not None and current_subscription.active
+    )
+    has_past_subscription = (
+        NotificationSubscription.query.filter(
+            NotificationSubscription.participant_id == participant.id,
+            NotificationSubscription.channel == "line",
+            NotificationSubscription.session_id != current_session.id,
+        ).first()
+        is not None
+    )
+
+    if not has_active_line_account:
+        state = "unlinked"
+    elif current_subscription_active:
+        state = "subscribed"
+    elif has_past_subscription:
+        state = "linked_past_session_only"
+    else:
+        state = "linked_unsubscribed"
+
+    return {
+        "state": state,
+        "has_active_line_account": has_active_line_account,
+        "current_subscription_active": current_subscription_active,
+        "has_past_subscription": has_past_subscription,
+    }
+
+
+def generate_line_link_token_value():
+    alphabet = string.ascii_uppercase + string.digits
+    for _ in range(10):
+        token = "".join(secrets.choice(alphabet) for _ in range(6))
+        if LineLinkToken.query.filter_by(token=token).first() is None:
+            return token
+    return secrets.token_urlsafe(8)[:12].upper()
+
 
 @app.route('/qrcode/<user_type>')
 def qrcode_image(user_type):
@@ -345,9 +414,76 @@ def qrcode_image(user_type):
 @app.route('/thanks')
 def thanks():
     mode = request.args.get('mode', 'viewer')
+    card = request.args.get('card')
     config = load_config()
     paypay_links = config.get("paypay_links", {})
-    return render_template('thanks.html', paypay_links=paypay_links, mode=mode)
+    participant = Participant.query.filter_by(card=card).first() if card else None
+    line_notification_status = None
+    if participant is not None:
+        current_session = ensure_current_match_session()
+        line_notification_status = get_line_notification_status(
+            participant, current_session
+        )
+    return render_template(
+        'thanks.html',
+        paypay_links=paypay_links,
+        mode=mode,
+        participant=participant,
+        line_notification_status=line_notification_status,
+    )
+
+
+@app.route('/notifications/line/start/<card>')
+def start_line_notification(card):
+    mode = request.args.get('mode', 'viewer')
+    participant = get_participant_by_card_or_404(card)
+    current_session = ensure_current_match_session()
+
+    if get_active_line_account(participant) is not None:
+        subscription = get_line_notification_subscription(
+            participant.id, current_session.id
+        )
+        if subscription is None:
+            subscription = NotificationSubscription(
+                session_id=current_session.id,
+                participant_id=participant.id,
+                channel="line",
+                active=True,
+            )
+            db.session.add(subscription)
+        elif not subscription.active:
+            subscription.active = True
+        db.session.commit()
+        flash("今回のLINE通知を登録しました", "success")
+        return redirect(url_for('thanks', mode=mode, card=participant.card))
+
+    token = LineLinkToken(
+        token=generate_line_link_token_value(),
+        participant_id=participant.id,
+        session_id=current_session.id,
+        expires_at=utc_now() + timedelta(minutes=30),
+    )
+    db.session.add(token)
+    db.session.commit()
+    return render_template(
+        'line_link_token.html',
+        participant=participant,
+        token=token,
+        mode=mode,
+    )
+
+
+@app.route('/notifications/line/unsubscribe/<card>', methods=['POST'])
+def unsubscribe_line_notification(card):
+    mode = request.form.get('mode', request.args.get('mode', 'viewer'))
+    participant = get_participant_by_card_or_404(card)
+    current_session = ensure_current_match_session()
+    subscription = get_line_notification_subscription(participant.id, current_session.id)
+    if subscription is not None and subscription.active:
+        subscription.active = False
+        db.session.commit()
+    flash("今回のLINE通知を解除しました", "success")
+    return redirect(url_for('thanks', mode=mode, card=participant.card))
 
 @app.route('/participant/<card>', methods=['GET', 'POST'])
 def participant_view(card):

--- a/app.py
+++ b/app.py
@@ -420,10 +420,13 @@ def thanks():
     participant = Participant.query.filter_by(card=card).first() if card else None
     line_notification_status = None
     if participant is not None:
-        current_session = ensure_current_match_session()
-        line_notification_status = get_line_notification_status(
-            participant, current_session
-        )
+        if participant.active:
+            current_session = ensure_current_match_session()
+            line_notification_status = get_line_notification_status(
+                participant, current_session
+            )
+        else:
+            line_notification_status = {"state": "inactive"}
     return render_template(
         'thanks.html',
         paypay_links=paypay_links,
@@ -437,6 +440,10 @@ def thanks():
 def start_line_notification(card):
     mode = request.args.get('mode', 'viewer')
     participant = get_participant_by_card_or_404(card)
+    if not participant.active:
+        flash("現在参加中の方のみLINE通知登録できます", "info")
+        return redirect(url_for('thanks', mode=mode, card=participant.card))
+
     current_session = ensure_current_match_session()
 
     if get_active_line_account(participant) is not None:

--- a/templates/line_link_token.html
+++ b/templates/line_link_token.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LINE通知連携コード</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            font-size: 16px;
+            padding: 20px;
+            max-width: 500px;
+            margin: auto;
+            background-color: #f9f9f9;
+            text-align: center;
+        }
+        .token-code {
+            display: inline-block;
+            margin: 20px 0;
+            padding: 16px 24px;
+            border: 2px dashed #06c755;
+            border-radius: 8px;
+            background: #fff;
+            color: #111;
+            font-size: 32px;
+            font-weight: bold;
+            letter-spacing: 0.15em;
+        }
+        .notice {
+            text-align: left;
+            line-height: 1.6;
+        }
+    </style>
+    {% include "_button_styles.html" %}
+</head>
+<body>
+    <h1>LINE通知の連携コード</h1>
+    <p>{{ participant.name }}さん、LINE Botを友だち追加して、以下のコードを送信してください。</p>
+
+    <div class="token-code">{{ token.token }}</div>
+
+    <div class="notice">
+        <p>このコードをBotに送信すると、今回の試合セッションのLINE通知登録に進めます。</p>
+        <p>有効期限: {{ token.expires_at.strftime('%Y-%m-%d %H:%M') }} UTC</p>
+        <p>※今回のPRでは、Bot側でコードを受け取るWebhookと通知送信は未実装です。</p>
+    </div>
+
+    <a href="{{ url_for('thanks', mode=mode, card=participant.card) }}" class="btn btn-secondary btn-block">登録完了画面に戻る</a>
+</body>
+</html>

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -60,6 +60,23 @@
         .back-link {
             background-color: #7d7d7d;
         }
+
+        .line-notification {
+            margin: 30px 0;
+            padding: 16px;
+            border-radius: 8px;
+            background: #fff;
+            border: 1px solid #e0e0e0;
+        }
+
+        .line-button {
+            background-color: #06c755;
+        }
+
+        .unsubscribe-button {
+            width: 100%;
+            background-color: #7d7d7d;
+        }
     </style>
     {% include "_button_styles.html" %}
 </head>
@@ -87,6 +104,25 @@
         🧑‍🎓 学生の方はこちら（300円）
     </a>
 </div>
+
+{% if participant and line_notification_status %}
+<div class="line-notification">
+    <h3>🔔 LINE通知</h3>
+    {% if line_notification_status.state == 'unlinked' %}
+        <p>LINE連携すると、今回の組み合わせ通知を受け取れるようになります。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE連携して通知を受け取る</a>
+    {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}
+        <p>LINE連携済みです。今回の通知を受け取るには登録してください。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">今回のLINE通知を受け取る</a>
+    {% elif line_notification_status.state == 'subscribed' %}
+        <p><strong>LINE通知登録済み</strong></p>
+        <form method="post" action="{{ url_for('unsubscribe_line_notification', card=participant.card) }}">
+            <input type="hidden" name="mode" value="{{ mode }}">
+            <button type="submit" class="btn btn-secondary btn-block unsubscribe-button">LINE通知を解除する</button>
+        </form>
+    {% endif %}
+</div>
+{% endif %}
 
 <p>お支払いが完了したら以下のボタンをタップしてください</p>
 {% if mode == 'admin' %}

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -82,6 +82,8 @@
 </head>
 <body>
 
+{% include "_flash_messages.html" %}
+
 <h1>登録完了</h1>
 
 <p>参加費のお支払いをお願いします🙇‍♂️</p>
@@ -108,7 +110,9 @@
 {% if participant and line_notification_status %}
 <div class="line-notification">
     <h3>🔔 LINE通知</h3>
-    {% if line_notification_status.state == 'unlinked' %}
+    {% if line_notification_status.state == 'inactive' %}
+        <p>現在参加中の方のみLINE通知登録できます。</p>
+    {% elif line_notification_status.state == 'unlinked' %}
         <p>LINE連携すると、今回の組み合わせ通知を受け取れるようになります。</p>
         <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE連携して通知を受け取る</a>
     {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -219,6 +219,102 @@ def test_thanks_page_line_notification_display_branches(app_module, participant)
         assert "LINE通知を解除する" in subscribed_html
 
 
+def test_inactive_linked_participant_start_does_not_create_current_subscription(
+    app_module, participant
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        player.active = False
+        add_line_account(app_module, participant)
+        app_module.db.session.commit()
+
+        response = client.get("/notifications/line/start/C1", follow_redirects=True)
+
+        assert response.status_code == 200
+        assert "現在参加中の方のみLINE通知登録できます" in response.get_data(
+            as_text=True
+        )
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.LineLinkToken.query.count() == 0
+
+
+def test_inactive_unlinked_participant_start_does_not_create_line_link_token(
+    app_module, participant
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        player.active = False
+        app_module.db.session.commit()
+
+        response = client.get("/notifications/line/start/C1", follow_redirects=True)
+
+        assert response.status_code == 200
+        assert "現在参加中の方のみLINE通知登録できます" in response.get_data(
+            as_text=True
+        )
+        assert app_module.LineLinkToken.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+
+
+def test_inactive_participant_thanks_page_hides_line_notification_buttons(
+    app_module, participant
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        player.active = False
+        app_module.db.session.commit()
+
+        html = client.get("/thanks?card=C1").get_data(as_text=True)
+
+        assert "現在参加中の方のみLINE通知登録できます" in html
+        assert "LINE連携して通知を受け取る" not in html
+        assert "今回のLINE通知を受け取る" not in html
+        assert "LINE通知を解除する" not in html
+
+
+def test_inactive_participant_with_past_subscription_is_not_registered_for_current_session(
+    app_module, participant, tmp_path
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        player.active = False
+        add_line_account(app_module, participant)
+        past_session = add_session(app_module, match_count=1)
+        current_session = add_session(app_module, match_count=2)
+        write_current_session(tmp_path, current_session.id)
+        app_module.db.session.add(
+            app_module.NotificationSubscription(
+                session_id=past_session.id,
+                participant_id=participant,
+                channel="line",
+                active=True,
+            )
+        )
+        app_module.db.session.commit()
+
+        response = client.get("/notifications/line/start/C1", follow_redirects=True)
+
+        assert response.status_code == 200
+        subscriptions = app_module.NotificationSubscription.query.order_by(
+            app_module.NotificationSubscription.session_id
+        ).all()
+        assert len(subscriptions) == 1
+        assert subscriptions[0].session_id == past_session.id
+        assert app_module.NotificationSubscription.query.filter_by(
+            session_id=current_session.id,
+            participant_id=participant,
+            channel="line",
+        ).first() is None
+
+
 def test_line_webhook_and_send_routes_are_not_implemented(app_module):
     client = app_module.app.test_client()
 

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -1,0 +1,226 @@
+import importlib
+import json
+import os
+import sys
+import pytest
+
+
+def load_test_app(monkeypatch, tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"paypay_links": {"adults": "#", "students": "#"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    os.makedirs(app_module.app.instance_path, exist_ok=True)
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.app_context():
+        app_module.db.drop_all()
+        app_module.db.create_all()
+    return app_module
+
+
+@pytest.fixture
+def app_module(monkeypatch, tmp_path):
+    return load_test_app(monkeypatch, tmp_path)
+
+
+@pytest.fixture
+def participant(app_module):
+    with app_module.app.app_context():
+        player = app_module.Participant(
+            name="line-player",
+            gender="male",
+            level="beginner",
+            weight=1.0,
+            card="C1",
+        )
+        app_module.db.session.add(player)
+        app_module.db.session.commit()
+        return player.id
+
+
+def get_participant(app_module, participant_id):
+    return app_module.db.session.get(app_module.Participant, participant_id)
+
+
+def add_line_account(app_module, participant_id, active=True):
+    account = app_module.LineAccount(
+        participant_id=participant_id,
+        line_user_id=f"U{participant_id}{active}",
+        display_name="Line Player",
+        active=active,
+    )
+    app_module.db.session.add(account)
+    app_module.db.session.commit()
+    return account
+
+
+def add_session(app_module, match_count=0):
+    session = app_module.MatchSession(match_count=match_count)
+    app_module.db.session.add(session)
+    app_module.db.session.commit()
+    return session
+
+
+def write_current_session(tmp_path, session_id):
+    (tmp_path / "match_state.json").write_text(
+        json.dumps({"session_id": session_id}), encoding="utf-8"
+    )
+
+
+def test_unlinked_participant_start_creates_line_link_token_for_current_session(
+    app_module, participant, tmp_path
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        response = client.get("/notifications/line/start/C1")
+
+        assert response.status_code == 200
+        token = app_module.LineLinkToken.query.one()
+        current_session_id = app_module.ensure_current_match_session().id
+        assert token.participant_id == participant
+        assert token.session_id == current_session_id
+        assert token.expires_at is not None
+        assert app_module.NotificationSubscription.query.count() == 0
+
+
+def test_linked_participant_start_creates_subscription_for_current_session(
+    app_module, participant
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        add_line_account(app_module, participant)
+        response = client.get("/notifications/line/start/C1")
+
+        assert response.status_code == 302
+        subscription = app_module.NotificationSubscription.query.one()
+        assert subscription.participant_id == participant
+        assert subscription.session_id == app_module.ensure_current_match_session().id
+        assert subscription.channel == "line"
+        assert subscription.active is True
+        assert app_module.LineLinkToken.query.count() == 0
+
+
+def test_same_session_registration_is_idempotent(app_module, participant):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        add_line_account(app_module, participant)
+        client.get("/notifications/line/start/C1")
+        client.get("/notifications/line/start/C1")
+
+        assert app_module.NotificationSubscription.query.count() == 1
+        assert app_module.NotificationSubscription.query.one().active is True
+
+
+def test_inactive_subscription_is_reactivated(app_module, participant):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        add_line_account(app_module, participant)
+        current_session = app_module.ensure_current_match_session()
+        subscription = app_module.NotificationSubscription(
+            session_id=current_session.id,
+            participant_id=participant,
+            channel="line",
+            active=False,
+        )
+        app_module.db.session.add(subscription)
+        app_module.db.session.commit()
+
+        client.get("/notifications/line/start/C1")
+
+        assert app_module.NotificationSubscription.query.count() == 1
+        assert app_module.NotificationSubscription.query.one().active is True
+
+
+def test_unsubscribe_only_deactivates_current_session_subscription_and_keeps_line_account(
+    app_module, participant, tmp_path
+):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        add_line_account(app_module, participant)
+        past_session = add_session(app_module, match_count=1)
+        current_session = add_session(app_module, match_count=2)
+        write_current_session(tmp_path, current_session.id)
+        past_subscription = app_module.NotificationSubscription(
+            session_id=past_session.id,
+            participant_id=participant,
+            channel="line",
+            active=True,
+        )
+        current_subscription = app_module.NotificationSubscription(
+            session_id=current_session.id,
+            participant_id=participant,
+            channel="line",
+            active=True,
+        )
+        app_module.db.session.add_all([past_subscription, current_subscription])
+        app_module.db.session.commit()
+
+        response = client.post("/notifications/line/unsubscribe/C1")
+
+        assert response.status_code == 302
+        assert app_module.db.session.get(app_module.LineAccount, 1) is not None
+        assert app_module.db.session.get(
+            app_module.NotificationSubscription, past_subscription.id
+        ).active is True
+        assert app_module.db.session.get(
+            app_module.NotificationSubscription, current_subscription.id
+        ).active is False
+
+
+def test_past_subscription_does_not_count_as_current_session_registered(
+    app_module, participant, tmp_path
+):
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        add_line_account(app_module, participant)
+        past_session = add_session(app_module, match_count=1)
+        current_session = add_session(app_module, match_count=2)
+        write_current_session(tmp_path, current_session.id)
+        app_module.db.session.add(
+            app_module.NotificationSubscription(
+                session_id=past_session.id,
+                participant_id=participant,
+                channel="line",
+                active=True,
+            )
+        )
+        app_module.db.session.commit()
+
+        status = app_module.get_line_notification_status(player, current_session)
+
+        assert status["state"] == "linked_past_session_only"
+        assert status["current_subscription_active"] is False
+        assert status["has_past_subscription"] is True
+
+
+def test_thanks_page_line_notification_display_branches(app_module, participant):
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        unlinked_html = client.get("/thanks?card=C1").get_data(as_text=True)
+        assert "LINE連携して通知を受け取る" in unlinked_html
+
+        add_line_account(app_module, participant)
+        linked_html = client.get("/thanks?card=C1").get_data(as_text=True)
+        assert "今回のLINE通知を受け取る" in linked_html
+        assert "LINE通知登録済み" not in linked_html
+
+        client.get("/notifications/line/start/C1")
+        subscribed_html = client.get("/thanks?card=C1").get_data(as_text=True)
+        assert "LINE通知登録済み" in subscribed_html
+        assert "LINE通知を解除する" in subscribed_html
+
+
+def test_line_webhook_and_send_routes_are_not_implemented(app_module):
+    client = app_module.app.test_client()
+
+    assert client.post("/line/webhook").status_code == 404
+    assert client.post("/notifications/line/send").status_code == 404


### PR DESCRIPTION
### Motivation
- Allow participants to register/unregister for LINE notifications scoped to the current `MatchSession` and surface appropriate UI on the participant "thanks" page.  
- Ensure registration logic distinguishes LINE account linkage from session-scoped subscription state so past-session subscriptions do not count as current-session registrations.  

### Description
- Add helpers in `app.py` to resolve a participant by `card`, detect active `LineAccount`, find the current-session `NotificationSubscription`, compute notification state (`unlinked`, `linked_unsubscribed`, `linked_past_session_only`, `subscribed`), and generate short unique link tokens.  
- Add route `GET /notifications/line/start/<card>` that creates/reactivates a current-session `NotificationSubscription` for linked participants or issues a `LineLinkToken` (with `expires_at`) for unlinked participants and renders `templates/line_link_token.html`.  
- Add route `POST /notifications/line/unsubscribe/<card>` that deactivates only the current-session `NotificationSubscription` while leaving `LineAccount` intact.  
- Update the participant flow to pass `card` through the thanks redirect and enhance `templates/thanks.html` with LINE-notification UI branches and an unsubscribe form; add new template `templates/line_link_token.html` for displaying issued tokens and expiry.  
- Add `tests/test_line_notification_routes.py` covering token creation, current-session scoping, subscription creation/idempotency/reactivation, unsubscribe behavior, thanks-page display branches, and verifying webhook/send routes are not implemented.  

### Testing
- Ran the focused route tests with `pytest tests/test_line_notification_routes.py -q`, which passed.  
- Ran the full suite with `pytest`, and all tests passed (`218 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c84d14af8833382ea710e9964de0d)