### PR TITLE
Add LINE webhook link completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ export SECRET_KEY='replace-with-a-long-random-secret'
 
 `SECRET_KEY` は Flask の session cookie 署名に使います。`SECRET_KEY` が設定されている場合はその値を使用します。未設定の場合、デフォルトでは起動に失敗します。ローカル開発だけで固定 fallback を使いたい場合は、明示的に `ALLOW_DEV_SECRET_KEY=1` を設定してください。本番環境では必ず環境変数 `SECRET_KEY` に推測困難な値を設定し、`ALLOW_DEV_SECRET_KEY=1` は使わないでください。
 
+LINE Bot Webhook で通知登録を受け付ける場合は、LINE Developers で発行した `LINE_CHANNEL_SECRET` と `LINE_CHANNEL_ACCESS_TOKEN` を環境変数に設定してください。
+
 ## 🧭 状態管理と Flask session の方針
 
 このアプリでは、業務状態の正本を client 単位の Flask session ではなく、用途ごとの共有 state store に分けて管理します。

--- a/app.py
+++ b/app.py
@@ -3,12 +3,17 @@ import os
 import json
 import io
 import logging
+import hmac
+import hashlib
+import base64
+import urllib.request
+import urllib.error
 import re
 import secrets
 import string
 from datetime import datetime, timedelta, timezone
 from io import TextIOWrapper
-from flask import Flask, render_template, request, redirect, url_for, abort
+from flask import Flask, render_template, request, redirect, url_for, abort, jsonify
 from models import (
     db,
     BenchHistory,
@@ -435,6 +440,148 @@ def thanks():
         line_notification_status=line_notification_status,
     )
 
+
+
+def verify_line_signature(raw_body, signature, channel_secret):
+    """Return True when LINE webhook signature matches the raw request body."""
+    if not channel_secret or not signature:
+        return False
+    digest = hmac.new(
+        channel_secret.encode("utf-8"), raw_body, hashlib.sha256
+    ).digest()
+    expected_signature = base64.b64encode(digest).decode("utf-8")
+    return hmac.compare_digest(expected_signature, signature)
+
+
+def send_line_reply(reply_token, message_text):
+    """Send a LINE Messaging API reply message."""
+    channel_access_token = os.environ.get("LINE_CHANNEL_ACCESS_TOKEN")
+    if not channel_access_token or not reply_token:
+        return False
+
+    payload = json.dumps(
+        {
+            "replyToken": reply_token,
+            "messages": [{"type": "text", "text": message_text}],
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.line.me/v2/bot/message/reply",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {channel_access_token}",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        return 200 <= response.status < 300
+
+
+def reply_line_message(reply_token, message_text):
+    if not reply_token:
+        return
+    try:
+        send_line_reply(reply_token, message_text)
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        app.logger.warning("Failed to send LINE reply: %s", error)
+
+
+def find_line_link_token(token_value):
+    return (
+        LineLinkToken.query.options(
+            selectinload(LineLinkToken.participant),
+            selectinload(LineLinkToken.session),
+        )
+        .filter_by(token=token_value)
+        .first()
+    )
+
+
+def complete_line_link(token_value, line_user_id):
+    now = utc_now()
+    link_token = find_line_link_token(token_value)
+    if link_token is None:
+        return False, "連携コードが見つかりません。コードを確認してください。"
+    if link_token.used_at is not None:
+        return False, "この連携コードはすでに使用されています。"
+    expires_at = link_token.expires_at
+    if expires_at.tzinfo is None:
+        now = now.replace(tzinfo=None)
+    if expires_at < now:
+        return False, "連携コードの有効期限が切れています。もう一度登録を開始してください。"
+    if link_token.participant is None or link_token.session is None:
+        return False, "連携コードが無効です。もう一度登録を開始してください。"
+    if not link_token.participant.active:
+        return False, "現在参加中ではないため、LINE通知登録はできません。"
+
+    conflicting_account = LineAccount.query.filter(
+        LineAccount.line_user_id == line_user_id,
+        LineAccount.participant_id != link_token.participant_id,
+    ).first()
+    if conflicting_account is not None:
+        return False, "このLINEアカウントは別の参加者に連携済みです。"
+
+    account = LineAccount.query.filter_by(
+        participant_id=link_token.participant_id
+    ).first()
+    if account is None:
+        account = LineAccount(
+            participant_id=link_token.participant_id,
+            line_user_id=line_user_id,
+            active=True,
+        )
+        db.session.add(account)
+    else:
+        account.line_user_id = line_user_id
+        account.active = True
+
+    subscription = get_line_notification_subscription(
+        link_token.participant_id, link_token.session_id
+    )
+    if subscription is None:
+        subscription = NotificationSubscription(
+            session_id=link_token.session_id,
+            participant_id=link_token.participant_id,
+            channel="line",
+            active=True,
+        )
+        db.session.add(subscription)
+    else:
+        subscription.active = True
+
+    link_token.used_at = now
+    db.session.commit()
+    return True, "LINE通知登録が完了しました。"
+
+
+def process_line_webhook_event(event):
+    if event.get("type") != "message":
+        return
+    message = event.get("message") or {}
+    if message.get("type") != "text":
+        return
+    line_user_id = (event.get("source") or {}).get("userId")
+    if not line_user_id:
+        return
+
+    token_value = (message.get("text") or "").strip()
+    success, reply_message = complete_line_link(token_value, line_user_id)
+    reply_line_message(event.get("replyToken"), reply_message)
+
+
+@app.route('/line/webhook', methods=['POST'])
+def line_webhook():
+    raw_body = request.get_data()
+    signature = request.headers.get("X-Line-Signature")
+    channel_secret = os.environ.get("LINE_CHANNEL_SECRET")
+    if not verify_line_signature(raw_body, signature, channel_secret):
+        return jsonify({"error": "invalid signature"}), 403
+
+    payload = request.get_json(silent=True) or {}
+    for event in payload.get("events", []):
+        process_line_webhook_event(event)
+    return jsonify({"status": "ok"})
 
 @app.route('/notifications/line/start/<card>')
 def start_line_notification(card):

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -2,6 +2,10 @@ import importlib
 import json
 import os
 import sys
+import hmac
+import hashlib
+import base64
+from datetime import timedelta
 import pytest
 
 
@@ -315,8 +319,252 @@ def test_inactive_participant_with_past_subscription_is_not_registered_for_curre
         ).first() is None
 
 
-def test_line_webhook_and_send_routes_are_not_implemented(app_module):
+
+def line_signature(body, secret="test-line-secret"):
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("utf-8")
+
+
+def post_line_webhook(client, payload, secret="test-line-secret", signature=True):
+    body = json.dumps(payload).encode("utf-8")
+    headers = {}
+    if signature:
+        headers["X-Line-Signature"] = line_signature(body, secret)
+    return client.post(
+        "/line/webhook", data=body, content_type="application/json", headers=headers
+    )
+
+
+def add_link_token(app_module, participant_id, session_id, token="ABC123", minutes=30):
+    token_row = app_module.LineLinkToken(
+        token=token,
+        participant_id=participant_id,
+        session_id=session_id,
+        expires_at=app_module.utc_now() + timedelta(minutes=minutes),
+    )
+    app_module.db.session.add(token_row)
+    app_module.db.session.commit()
+    return token_row
+
+
+def line_text_event(text="ABC123", user_id="U111", reply_token="reply-token"):
+    return {
+        "type": "message",
+        "replyToken": reply_token,
+        "source": {"type": "user", "userId": user_id},
+        "message": {"type": "text", "text": text},
+    }
+
+
+def test_line_webhook_valid_text_code_creates_account_subscription_and_uses_token(
+    app_module, participant, monkeypatch
+):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "test-access-token")
+    replies = []
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: replies.append((token, text)) or True)
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+
+        response = post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert response.status_code == 200
+        account = app_module.LineAccount.query.one()
+        assert account.participant_id == participant
+        assert account.line_user_id == "U111"
+        subscription = app_module.NotificationSubscription.query.one()
+        assert subscription.session_id == session.id
+        assert subscription.participant_id == participant
+        assert subscription.channel == "line"
+        assert subscription.active is True
+        assert app_module.LineLinkToken.query.one().used_at is not None
+        assert replies == [("reply-token", "LINE通知登録が完了しました。")]
+
+
+def test_line_webhook_same_code_cannot_be_reused(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+        post_line_webhook(client, {"events": [line_text_event(user_id="U111")]})
+        post_line_webhook(client, {"events": [line_text_event(user_id="U222")]})
+
+        assert app_module.LineAccount.query.count() == 1
+        assert app_module.LineAccount.query.one().line_user_id == "U111"
+        assert app_module.NotificationSubscription.query.count() == 1
+
+
+def test_line_webhook_expired_code_is_rejected_without_creating_records(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        token = add_link_token(app_module, participant, session.id, minutes=-1)
+        response = post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.db.session.get(app_module.LineLinkToken, token.id).used_at is None
+
+
+def test_line_webhook_unknown_code_is_rejected(app_module, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        response = post_line_webhook(client, {"events": [line_text_event(text="NOPE")]})
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+
+
+def test_line_webhook_inactive_participant_code_is_rejected(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        player = get_participant(app_module, participant)
+        player.active = False
+        session = add_session(app_module)
+        token = add_link_token(app_module, participant, session.id)
+        app_module.db.session.commit()
+
+        response = post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.db.session.get(app_module.LineLinkToken, token.id).used_at is None
+
+
+def test_line_webhook_existing_participant_account_is_updated(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        account = add_line_account(app_module, participant, active=False)
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+
+        post_line_webhook(client, {"events": [line_text_event(user_id="UNEW")]})
+
+        assert app_module.LineAccount.query.count() == 1
+        updated = app_module.db.session.get(app_module.LineAccount, account.id)
+        assert updated.line_user_id == "UNEW"
+        assert updated.active is True
+
+
+def test_line_webhook_rejects_line_user_id_linked_to_another_participant(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        other = app_module.Participant(name="other", gender="male", level="beginner", weight=1.0, card="C2")
+        app_module.db.session.add(other)
+        app_module.db.session.commit()
+        add_line_account(app_module, other.id)
+        account = app_module.LineAccount.query.filter_by(participant_id=other.id).one()
+        account.line_user_id = "UCONFLICT"
+        session = add_session(app_module)
+        token = add_link_token(app_module, participant, session.id)
+        app_module.db.session.commit()
+
+        post_line_webhook(client, {"events": [line_text_event(user_id="UCONFLICT")]})
+
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.db.session.get(app_module.LineLinkToken, token.id).used_at is None
+        assert app_module.LineAccount.query.count() == 1
+
+
+def test_line_webhook_reactivates_inactive_subscription(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        subscription = app_module.NotificationSubscription(session_id=session.id, participant_id=participant, channel="line", active=False)
+        app_module.db.session.add(subscription)
+        add_link_token(app_module, participant, session.id)
+        app_module.db.session.commit()
+
+        post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert app_module.NotificationSubscription.query.count() == 1
+        assert app_module.db.session.get(app_module.NotificationSubscription, subscription.id).active is True
+
+
+def test_line_webhook_does_not_duplicate_active_subscription(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: True)
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        app_module.db.session.add(app_module.NotificationSubscription(session_id=session.id, participant_id=participant, channel="line", active=True))
+        add_link_token(app_module, participant, session.id)
+        app_module.db.session.commit()
+
+        post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert app_module.NotificationSubscription.query.count() == 1
+
+
+def test_line_webhook_invalid_missing_or_unconfigured_signature_is_not_processed(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    body_payload = {"events": [line_text_event()]}
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+        bad_body = json.dumps(body_payload).encode("utf-8")
+        assert client.post("/line/webhook", data=bad_body, content_type="application/json", headers={"X-Line-Signature": "bad"}).status_code == 403
+        assert post_line_webhook(client, body_payload, signature=False).status_code == 403
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        assert post_line_webhook(client, body_payload).status_code == 403
+        assert app_module.LineAccount.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.LineLinkToken.query.one().used_at is None
+
+
+def test_line_webhook_ignores_non_text_or_userless_events(app_module, participant, monkeypatch):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+        payload = {"events": [
+            {"type": "follow", "replyToken": "r", "source": {"type": "user", "userId": "U1"}},
+            {"type": "message", "replyToken": "r", "source": {"type": "user", "userId": "U1"}, "message": {"type": "image"}},
+            {"type": "message", "replyToken": "r", "source": {"type": "group"}, "message": {"type": "text", "text": "ABC123"}},
+        ]}
+
+        response = post_line_webhook(client, payload)
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+        assert app_module.LineLinkToken.query.one().used_at is None
+
+
+def test_line_push_send_route_is_not_implemented(app_module):
     client = app_module.app.test_client()
 
-    assert client.post("/line/webhook").status_code == 404
     assert client.post("/notifications/line/send").status_code == 404


### PR DESCRIPTION
### Motivation
- LINE Bot 経由で配布した連携コードを受け取り参加者と LINE アカウントを紐づけ、同時に当該 `MatchSession` 単位の `NotificationSubscription` を作成または再有効化するためのサーバ側受信処理を追加する。 
- セキュリティのため webhook は `X-Line-Signature` と `LINE_CHANNEL_SECRET` による署名検証を行い、不正や未設定時は処理しないようにする。 
- 今回は連携完了（account/subscription の作成）までを実装し、Push送信やLIFF、勝敗入力、リッチメニュー等は実装しない。 

### Description
- 受信エンドポイントとして `POST /line/webhook` を追加し、リクエストの raw body と `X-Line-Signature` を `LINE_CHANNEL_SECRET` で検証する処理を実装した（署名不正・未設定時は 403 を返す）。
- 署名検証と返信送信を行う `verify_line_signature` と `send_line_reply` を追加し、HTTP送信は `send_line_reply` に切り出してテストでモック可能にした。 
- テキストメッセージイベントのみを処理対象とし、メッセージ本文を trim した文字列を `LineLinkToken.token` と照合する `process_line_webhook_event` / `complete_line_link` を実装した。 
- 有効なトークンの場合は `LineAccount` を作成または更新し、同一 `participant_id` に紐づく `LineAccount` を更新、別の `participant_id` に同じ `line_user_id` が紐づく場合は拒否するロジックを追加した。 
- 有効なトークンに対しては `NotificationSubscription` を `session_id` / `participant_id` / `channel="line"` 単位で作成または再有効化し、成功時に `LineLinkToken.used_at` を設定して DB をコミットするようにした。 
- 非対象イベント（text以外、userId が取れない group イベント、follow/unfollow 等）はエラーにせず無視して 200 を返すようにした。 
- `README.md` に必要な環境変数として `LINE_CHANNEL_SECRET` と `LINE_CHANNEL_ACCESS_TOKEN` の記載を追記した。 
- 変更ファイルは主に `app.py`、テストの拡張を行った `tests/test_line_notification_routes.py`、および `README.md` で、実装は既存の `LineLinkToken` / `LineAccount` / `NotificationSubscription` モデルと整合するように実装している。 

### Testing
- 単体テストとして `pytest tests/test_line_notification_routes.py` を実行し、該当ファイルのテストはすべて成功（`23 passed`）。
- 全テストスイートを `pytest` で実行し、`233 passed` で全て通過した。 
- テストでは `send_line_reply` をモックして外部 HTTP へ依存しないようにしているため、reply の送信動作はテスト内で検証され、実ネットワーク呼び出しは発生していない。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c98d8d6e08333bfe07b9933c7fc17)