### PR TITLE
Improve LINE link flow and include PayPay links in LINE reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ export SECRET_KEY='replace-with-a-long-random-secret'
 
 `SECRET_KEY` は Flask の session cookie 署名に使います。`SECRET_KEY` が設定されている場合はその値を使用します。未設定の場合、デフォルトでは起動に失敗します。ローカル開発だけで固定 fallback を使いたい場合は、明示的に `ALLOW_DEV_SECRET_KEY=1` を設定してください。本番環境では必ず環境変数 `SECRET_KEY` に推測困難な値を設定し、`ALLOW_DEV_SECRET_KEY=1` は使わないでください。
 
-LINE Bot Webhook で通知登録を受け付ける場合は、LINE Developers で発行した `LINE_CHANNEL_SECRET` と `LINE_CHANNEL_ACCESS_TOKEN` を環境変数に設定してください。
+LINE Bot Webhook で通知登録を受け付ける場合は、LINE Developers で発行した `LINE_CHANNEL_SECRET` と `LINE_CHANNEL_ACCESS_TOKEN` を環境変数に設定してください。参加者をLINE Botへ案内するボタンを表示する場合は、友だち追加またはトークを開くURLを `LINE_BOT_FRIEND_URL` に設定してください。
+
+```bash
+LINE_BOT_FRIEND_URL=https://lin.ee/xxxxxxx
+```
 
 ## 🧭 状態管理と Flask session の方針
 

--- a/app.py
+++ b/app.py
@@ -612,6 +612,38 @@ def find_line_link_token(token_value):
     )
 
 
+def format_paypay_links_for_line(paypay_links):
+    if not isinstance(paypay_links, dict):
+        return ""
+    labels = {"adults": "大人", "students": "学生"}
+    lines = []
+    for key in ("adults", "students"):
+        url = (paypay_links.get(key) or "").strip()
+        if url:
+            lines.append(f"{labels[key]}: {url}")
+    for key, url_value in paypay_links.items():
+        if key in labels:
+            continue
+        url = (url_value or "").strip() if isinstance(url_value, str) else ""
+        if url:
+            lines.append(f"{key}: {url}")
+    if not lines:
+        return ""
+    return "\n\n続けて参加費のお支払いをお願いします。\nPayPayはこちら:\n" + "\n".join(lines)
+
+
+def build_line_link_success_message():
+    message = "LINE通知登録が完了しました🏸\n組み合わせが確定したらLINEでお知らせします。"
+    try:
+        paypay_text = format_paypay_links_for_line(
+            load_config().get("paypay_links", {})
+        )
+    except (OSError, json.JSONDecodeError, TypeError, AttributeError) as error:
+        app.logger.warning("Failed to load PayPay links for LINE reply: %s", error)
+        paypay_text = ""
+    return message + paypay_text
+
+
 def complete_line_link(token_value, line_user_id):
     now = utc_now()
     link_token = find_line_link_token(token_value)
@@ -666,7 +698,7 @@ def complete_line_link(token_value, line_user_id):
 
     link_token.used_at = now
     db.session.commit()
-    return True, "LINE通知登録が完了しました。"
+    return True, build_line_link_success_message()
 
 
 def process_line_webhook_event(event):
@@ -738,6 +770,7 @@ def start_line_notification(card):
         participant=participant,
         token=token,
         mode=mode,
+        line_bot_friend_url=os.environ.get("LINE_BOT_FRIEND_URL", "").strip(),
     )
 
 

--- a/app.py
+++ b/app.py
@@ -613,23 +613,32 @@ def find_line_link_token(token_value):
 
 
 def format_paypay_links_for_line(paypay_links):
+    lines = [
+        "続けて参加費のお支払いをお願いします。",
+        "社会人：600円",
+        "学生：300円",
+    ]
+    missing_links_message = "PayPayリンクが未設定のため、現地でお支払いください。"
     if not isinstance(paypay_links, dict):
-        return ""
-    labels = {"adults": "大人", "students": "学生"}
-    lines = []
+        return "\n\n" + "\n".join(lines + ["", missing_links_message])
+    labels = {
+        "adults": "社会人の方はこちら（600円）",
+        "students": "学生の方はこちら（300円）",
+    }
+    link_lines = []
     for key in ("adults", "students"):
         url = (paypay_links.get(key) or "").strip()
         if url:
-            lines.append(f"{labels[key]}: {url}")
+            link_lines.extend([labels[key], url])
     for key, url_value in paypay_links.items():
         if key in labels:
             continue
         url = (url_value or "").strip() if isinstance(url_value, str) else ""
         if url:
-            lines.append(f"{key}: {url}")
-    if not lines:
-        return ""
-    return "\n\n続けて参加費のお支払いをお願いします。\nPayPayはこちら:\n" + "\n".join(lines)
+            link_lines.extend([f"{key}はこちら", url])
+    if link_lines:
+        return "\n\n" + "\n".join(lines + ["", "PayPayはこちら:"] + link_lines)
+    return "\n\n" + "\n".join(lines + ["", missing_links_message])
 
 
 def build_line_link_success_message():

--- a/templates/line_link_token.html
+++ b/templates/line_link_token.html
@@ -2,48 +2,64 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>LINE通知連携コード</title>
+    <title>LINE通知登録</title>
     <style>
-        body {
-            font-family: sans-serif;
-            font-size: 16px;
-            padding: 20px;
-            max-width: 500px;
-            margin: auto;
-            background-color: #f9f9f9;
-            text-align: center;
-        }
-        .token-code {
-            display: inline-block;
-            margin: 20px 0;
-            padding: 16px 24px;
-            border: 2px dashed #06c755;
-            border-radius: 8px;
-            background: #fff;
-            color: #111;
-            font-size: 32px;
-            font-weight: bold;
-            letter-spacing: 0.15em;
-        }
-        .notice {
-            text-align: left;
-            line-height: 1.6;
-        }
+        body { font-family: sans-serif; font-size: 16px; padding: 20px; max-width: 500px; margin: auto; background-color: #f9f9f9; text-align: center; }
+        .step { margin: 22px 0 10px; font-weight: bold; text-align: left; }
+        .token-code { display: block; width: 100%; margin: 14px 0 8px; padding: 18px 12px; border: 2px dashed #06c755; border-radius: 8px; background: #fff; color: #111; font-size: 34px; font-weight: bold; letter-spacing: 0.15em; cursor: pointer; user-select: all; overflow-wrap: anywhere; }
+        .copy-status { min-height: 1.5em; margin: 8px 0; color: #067a37; font-weight: bold; }
+        .copy-status.error { color: #b00020; }
+        .notice { text-align: left; line-height: 1.6; }
+        .line-open-button { background: #06c755; color: #fff; }
+        .line-open-button:hover { background: #05ad4a; }
+        .muted { color: #666; font-size: 0.95em; }
     </style>
     {% include "_button_styles.html" %}
 </head>
 <body>
-    <h1>LINE通知の連携コード</h1>
-    <p>{{ participant.name }}さん、LINE Botを友だち追加して、以下のコードを送信してください。</p>
+    <h1>LINE通知登録</h1>
+    <p>{{ participant.name }}さん、以下の手順でLINE通知を登録してください。</p>
 
-    <div class="token-code">{{ token.token }}</div>
+    <p class="step">1. 連携コードをタップしてコピーしてください</p>
+    <button type="button" id="line-link-code" class="token-code" data-token="{{ token.token }}" aria-label="連携コード {{ token.token }} をコピー">
+        {{ token.token }}
+    </button>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+    <p class="muted">コピーできない場合は、コードを長押ししてコピーしてください。</p>
 
     <div class="notice">
-        <p>このコードをBotに送信すると、今回の試合セッションのLINE通知登録に進めます。</p>
+        <p class="step">2. LINE Botを開いて、コピーしたコードを貼り付けて送信してください</p>
+        {% if line_bot_friend_url %}
+            <a href="{{ line_bot_friend_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-block line-open-button">LINEでBotを開く</a>
+        {% else %}
+            <p class="muted">LINE Bot URLが未設定です。イベント運営者にLINE BotのURLを確認してください。</p>
+        {% endif %}
+        <p>友だち追加画面が表示された場合は、友だち追加後、トーク画面でコピーしたコードを送信してください。</p>
         <p>有効期限: {{ token.expires_at.strftime('%Y-%m-%d %H:%M') }} UTC</p>
-        <p>※今回のPRでは、Bot側でコードを受け取るWebhookと通知送信は未実装です。</p>
     </div>
 
-    <a href="{{ url_for('thanks', mode=mode, card=participant.card) }}" class="btn btn-secondary btn-block">登録完了画面に戻る</a>
+    <a href="{{ url_for('admin_index') if mode == 'admin' else url_for('viewer_index') }}" class="btn btn-secondary btn-block">トップへ戻る</a>
+
+    <script>
+        const codeButton = document.getElementById('line-link-code');
+        const copyStatus = document.getElementById('copy-status');
+
+        codeButton.addEventListener('click', async () => {
+            const token = codeButton.dataset.token;
+            copyStatus.classList.remove('error');
+            if (!navigator.clipboard || !navigator.clipboard.writeText) {
+                copyStatus.textContent = 'コピーできませんでした。コードを長押ししてコピーしてください。';
+                copyStatus.classList.add('error');
+                return;
+            }
+            try {
+                await navigator.clipboard.writeText(token);
+                copyStatus.textContent = 'コピーしました';
+            } catch (error) {
+                copyStatus.textContent = 'コピーできませんでした。コードを長押ししてコピーしてください。';
+                copyStatus.classList.add('error');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -86,12 +86,6 @@
 
 <h1>登録完了</h1>
 
-<p>参加費のお支払いをお願いします🙇‍♂️</p>
-<ul>
-    <li><strong>社会人：</strong>600円</li>
-    <li><strong>学生：</strong>300円</li>
-</ul>
-
 {% if participant and line_notification_status %}
 <div class="line-notification">
     <h3>🔔 LINE通知</h3>
@@ -116,6 +110,13 @@
 </div>
 {% endif %}
 
+<section class="payment-guidance">
+<h3>参加費</h3>
+<ul>
+    <li>社会人：600円</li>
+    <li>学生：300円</li>
+</ul>
+
 <h3>💰現金でお支払いの方</h3>
 参加費をかごに入れてください。
 <h3>📱 PayPayでお支払いの方</h3>
@@ -131,6 +132,7 @@
         🧑‍🎓 学生の方はこちら（300円）
     </a>
 </div>
+</section>
 
 <p>お支払いが完了したら以下のボタンをタップしてください</p>
 {% if mode == 'admin' %}

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -91,10 +91,35 @@
     <li><strong>社会人：</strong>600円</li>
     <li><strong>学生：</strong>300円</li>
 </ul>
+
+{% if participant and line_notification_status %}
+<div class="line-notification">
+    <h3>🔔 LINE通知</h3>
+    {% if line_notification_status.state == 'inactive' %}
+        <p>現在参加中の方のみLINE通知登録できます。</p>
+    {% elif line_notification_status.state == 'unlinked' %}
+        <p><strong>まずLINE通知登録をお願いします。</strong></p>
+        <p>組み合わせ確定通知と支払いリンクをLINEで受け取れます。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE通知を登録する</a>
+    {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}
+        <p><strong>LINE連携済みです。</strong></p>
+        <p>今回の組み合わせ通知を受け取るには通知登録してください。通知登録後、LINE上で支払いリンクも案内されます。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">今回のLINE通知を受け取る</a>
+    {% elif line_notification_status.state == 'subscribed' %}
+        <p>LINE通知登録済みです。</p>
+        <p>組み合わせ確定通知と支払いリンクはLINEでも案内されます。</p>
+        <form method="post" action="{{ url_for('unsubscribe_line_notification', card=participant.card) }}">
+            <input type="hidden" name="mode" value="{{ mode }}">
+            <button type="submit" class="btn btn-secondary btn-block unsubscribe-button">LINE通知を解除する</button>
+        </form>
+    {% endif %}
+</div>
+{% endif %}
+
 <h3>💰現金でお支払いの方</h3>
 参加費をかごに入れてください。
 <h3>📱 PayPayでお支払いの方</h3>
-<p>以下のボタンをタップしてPayPayでお支払いをお願いします。</p>
+<p>LINEを使わない場合、または先に支払う場合はこちらからお支払いください。</p>
 <div style="margin-bottom: 20px;">
     <a href="{{ paypay_links.get('adults') }}" target="_blank" rel="noopener noreferrer" class="pay-button adult">
         💳 社会人の方はこちら（600円）
@@ -106,27 +131,6 @@
         🧑‍🎓 学生の方はこちら（300円）
     </a>
 </div>
-
-{% if participant and line_notification_status %}
-<div class="line-notification">
-    <h3>🔔 LINE通知</h3>
-    {% if line_notification_status.state == 'inactive' %}
-        <p>現在参加中の方のみLINE通知登録できます。</p>
-    {% elif line_notification_status.state == 'unlinked' %}
-        <p>LINE連携すると、今回の組み合わせ通知を受け取れるようになります。</p>
-        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE連携して通知を受け取る</a>
-    {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}
-        <p>LINE連携済みです。今回の通知を受け取るには登録してください。</p>
-        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">今回のLINE通知を受け取る</a>
-    {% elif line_notification_status.state == 'subscribed' %}
-        <p><strong>LINE通知登録済み</strong></p>
-        <form method="post" action="{{ url_for('unsubscribe_line_notification', card=participant.card) }}">
-            <input type="hidden" name="mode" value="{{ mode }}">
-            <button type="submit" class="btn btn-secondary btn-block unsubscribe-button">LINE通知を解除する</button>
-        </form>
-    {% endif %}
-</div>
-{% endif %}
 
 <p>お支払いが完了したら以下のボタンをタップしてください</p>
 {% if mode == 'admin' %}

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -247,6 +247,9 @@ def test_thanks_page_line_notification_display_branches(app_module, participant)
         assert "組み合わせ確定通知と支払いリンクをLINEで受け取れます" in unlinked_html
         assert "LINE通知を登録する" in unlinked_html
         assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("📱 PayPay")
+        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("社会人：600円")
+        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("学生：300円")
+        assert unlinked_html.index("📱 PayPay") > unlinked_html.index("参加費")
         assert "LINEを使わない場合、または先に支払う場合はこちら" in unlinked_html
 
         add_line_account(app_module, participant)
@@ -431,9 +434,11 @@ def test_line_webhook_valid_text_code_creates_account_subscription_and_uses_toke
         assert "LINE通知登録が完了しました🏸" in reply_text
         assert "組み合わせが確定したらLINEでお知らせします。" in reply_text
         assert "続けて参加費のお支払いをお願いします。" in reply_text
+        assert "社会人：600円" in reply_text
+        assert "学生：300円" in reply_text
         assert "PayPayはこちら:" in reply_text
-        assert "大人: https://example.com/pay/adults" in reply_text
-        assert "学生: https://example.com/pay/students" in reply_text
+        assert "社会人の方はこちら（600円）\nhttps://example.com/pay/adults" in reply_text
+        assert "学生の方はこちら（300円）\nhttps://example.com/pay/students" in reply_text
 
 
 def test_line_webhook_same_code_cannot_be_reused(app_module, participant, monkeypatch):
@@ -647,9 +652,44 @@ def test_line_webhook_success_without_paypay_links_still_registers(
         assert app_module.LineAccount.query.count() == 1
         assert app_module.NotificationSubscription.query.count() == 1
         assert app_module.LineLinkToken.query.one().used_at is not None
-        assert replies == [
-            (
-                "reply-token",
-                "LINE通知登録が完了しました🏸\n組み合わせが確定したらLINEでお知らせします。",
-            )
-        ]
+        assert len(replies) == 1
+        assert replies[0][0] == "reply-token"
+        reply_text = replies[0][1]
+        assert "LINE通知登録が完了しました🏸" in reply_text
+        assert "続けて参加費のお支払いをお願いします。" in reply_text
+        assert "社会人：600円" in reply_text
+        assert "学生：300円" in reply_text
+        assert "PayPayリンクが未設定のため、現地でお支払いください。" in reply_text
+
+
+def test_line_webhook_success_with_one_paypay_link_includes_available_link(
+    app_module, participant, monkeypatch, tmp_path
+):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    (tmp_path / "config.json").write_text(
+        json.dumps({"paypay_links": {"adults": "https://example.com/pay/adults"}}),
+        encoding="utf-8",
+    )
+    replies = []
+    monkeypatch.setattr(
+        app_module,
+        "send_line_reply",
+        lambda token, text: replies.append((token, text)) or True,
+    )
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+
+        response = post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 1
+        assert app_module.NotificationSubscription.query.count() == 1
+        reply_text = replies[0][1]
+        assert "社会人：600円" in reply_text
+        assert "学生：300円" in reply_text
+        assert "社会人の方はこちら（600円）\nhttps://example.com/pay/adults" in reply_text
+        assert "学生の方はこちら（300円）" not in reply_text
+        assert "PayPayリンクが未設定" not in reply_text

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -11,7 +11,14 @@ import pytest
 
 def load_test_app(monkeypatch, tmp_path):
     (tmp_path / "config.json").write_text(
-        json.dumps({"paypay_links": {"adults": "#", "students": "#"}}),
+        json.dumps(
+            {
+                "paypay_links": {
+                    "adults": "https://example.com/pay/adults",
+                    "students": "https://example.com/pay/students",
+                }
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -75,8 +82,9 @@ def write_current_session(tmp_path, session_id):
 
 
 def test_unlinked_participant_start_creates_line_link_token_for_current_session(
-    app_module, participant, tmp_path
+    app_module, participant, tmp_path, monkeypatch
 ):
+    monkeypatch.setenv("LINE_BOT_FRIEND_URL", "https://lin.ee/example")
     client = app_module.app.test_client()
 
     with app_module.app.app_context():
@@ -89,6 +97,31 @@ def test_unlinked_participant_start_creates_line_link_token_for_current_session(
         assert token.session_id == current_session_id
         assert token.expires_at is not None
         assert app_module.NotificationSubscription.query.count() == 0
+        html = response.get_data(as_text=True)
+        assert "LINE通知登録" in html
+        assert "LINEでBotを開く" in html
+        assert "https://lin.ee/example" in html
+        assert "id=\"line-link-code\"" in html
+        assert "id=\"copy-status\"" in html
+        assert "コピーしました" in html
+        assert "トップへ戻る" in html
+        assert "/thanks" not in html
+
+
+def test_line_link_token_page_without_bot_url_is_safe(
+    app_module, participant, monkeypatch
+):
+    client = app_module.app.test_client()
+    monkeypatch.delenv("LINE_BOT_FRIEND_URL", raising=False)
+
+    with app_module.app.app_context():
+        response = client.get("/notifications/line/start/C1")
+
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert "LINE Bot URLが未設定です" in html
+        assert "LINEでBotを開く" not in html
+        assert app_module.LineLinkToken.query.count() == 1
 
 
 def test_linked_participant_start_creates_subscription_for_current_session(
@@ -363,7 +396,11 @@ def test_line_webhook_valid_text_code_creates_account_subscription_and_uses_toke
     monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
     monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "test-access-token")
     replies = []
-    monkeypatch.setattr(app_module, "send_line_reply", lambda token, text: replies.append((token, text)) or True)
+    monkeypatch.setattr(
+        app_module,
+        "send_line_reply",
+        lambda token, text: replies.append((token, text)) or True,
+    )
 
     with app_module.app.app_context():
         session = add_session(app_module)
@@ -381,7 +418,15 @@ def test_line_webhook_valid_text_code_creates_account_subscription_and_uses_toke
         assert subscription.channel == "line"
         assert subscription.active is True
         assert app_module.LineLinkToken.query.one().used_at is not None
-        assert replies == [("reply-token", "LINE通知登録が完了しました。")]
+        assert len(replies) == 1
+        assert replies[0][0] == "reply-token"
+        reply_text = replies[0][1]
+        assert "LINE通知登録が完了しました🏸" in reply_text
+        assert "組み合わせが確定したらLINEでお知らせします。" in reply_text
+        assert "続けて参加費のお支払いをお願いします。" in reply_text
+        assert "PayPayはこちら:" in reply_text
+        assert "大人: https://example.com/pay/adults" in reply_text
+        assert "学生: https://example.com/pay/students" in reply_text
 
 
 def test_line_webhook_same_code_cannot_be_reused(app_module, participant, monkeypatch):
@@ -568,3 +613,36 @@ def test_line_push_send_route_is_not_implemented(app_module):
     client = app_module.app.test_client()
 
     assert client.post("/notifications/line/send").status_code == 404
+
+
+def test_line_webhook_success_without_paypay_links_still_registers(
+    app_module, participant, monkeypatch, tmp_path
+):
+    client = app_module.app.test_client()
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    (tmp_path / "config.json").write_text(
+        json.dumps({"paypay_links": {}}), encoding="utf-8"
+    )
+    replies = []
+    monkeypatch.setattr(
+        app_module,
+        "send_line_reply",
+        lambda token, text: replies.append((token, text)) or True,
+    )
+
+    with app_module.app.app_context():
+        session = add_session(app_module)
+        add_link_token(app_module, participant, session.id)
+
+        response = post_line_webhook(client, {"events": [line_text_event()]})
+
+        assert response.status_code == 200
+        assert app_module.LineAccount.query.count() == 1
+        assert app_module.NotificationSubscription.query.count() == 1
+        assert app_module.LineLinkToken.query.one().used_at is not None
+        assert replies == [
+            (
+                "reply-token",
+                "LINE通知登録が完了しました🏸\n組み合わせが確定したらLINEでお知らせします。",
+            )
+        ]

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -243,10 +243,17 @@ def test_thanks_page_line_notification_display_branches(app_module, participant)
 
     with app_module.app.app_context():
         unlinked_html = client.get("/thanks?card=C1").get_data(as_text=True)
-        assert "LINE連携して通知を受け取る" in unlinked_html
+        assert "まずLINE通知登録をお願いします" in unlinked_html
+        assert "組み合わせ確定通知と支払いリンクをLINEで受け取れます" in unlinked_html
+        assert "LINE通知を登録する" in unlinked_html
+        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("📱 PayPay")
+        assert "LINEを使わない場合、または先に支払う場合はこちら" in unlinked_html
 
         add_line_account(app_module, participant)
         linked_html = client.get("/thanks?card=C1").get_data(as_text=True)
+        assert "LINE連携済みです" in linked_html
+        assert "今回の組み合わせ通知を受け取るには通知登録してください" in linked_html
+        assert "通知登録後、LINE上で支払いリンクも案内されます" in linked_html
         assert "今回のLINE通知を受け取る" in linked_html
         assert "LINE通知登録済み" not in linked_html
 
@@ -310,7 +317,7 @@ def test_inactive_participant_thanks_page_hides_line_notification_buttons(
         html = client.get("/thanks?card=C1").get_data(as_text=True)
 
         assert "現在参加中の方のみLINE通知登録できます" in html
-        assert "LINE連携して通知を受け取る" not in html
+        assert "LINE通知を登録する" not in html
         assert "今回のLINE通知を受け取る" not in html
         assert "LINE通知を解除する" not in html
 


### PR DESCRIPTION
### Motivation
- Participants frequently leave the web app after opening LINE so the link flow should be "copy code → open Bot → paste" to increase completion. 
- After successful LINE linkage the Bot reply should also guide users to pay, so include PayPay links in the reply when configured. 
- The Bot open URL must be configurable and safe when unset to avoid breaking the app.

### Description
- Add support for the `LINE_BOT_FRIEND_URL` environment variable and pass it to the `line_link_token.html` template, and document the variable in `README.md`.
- Add `format_paypay_links_for_line` and `build_line_link_success_message` in `app.py` and change `complete_line_link` to use the composed message so LINE reply includes PayPay links when available.
- Revamp `templates/line_link_token.html` to present a large tappable code that copies via the Clipboard API, show copy success/failure status, conditionally render a "LINEでBotを開く" button when `LINE_BOT_FRIEND_URL` is set, provide a long-press fallback message, and change the return link to the top page (`viewer`/`admin` aware).
- Update and add tests in `tests/test_line_notification_routes.py` to assert Bot button rendering and fallback, presence of copy UI elements and copy-status text, that the return link is the top page (not `thanks`), that the LINE webhook success reply contains PayPay guidance, and that missing PayPay links do not break registration.

### Testing
- Ran `pytest tests/test_line_notification_routes.py` and the updated webhook and UI assertions passed.
- Ran the full test suite with `pytest` and all tests passed (`243 passed`).
- Verified `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4da13c5eb0833388333142425e7106)