### PR TITLE
Personalize LINE match confirmation notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,16 +417,81 @@ def get_line_push_notification_targets(match_session):
     )
 
 
-def build_match_confirmed_line_message():
-    match_result_url = url_for("match_result", _external=True)
-    return (
-        "🏸 組み合わせが確定しました\n\n"
-        "今回の組み合わせを確認してください。\n"
-        f"{match_result_url}"
-    )
+def format_line_participant_label(participant):
+    if participant is None:
+        return "不明な参加者"
+
+    card = (participant.card or "").strip()
+    if card in ("JOKER_RED", "JOKER_BLACK"):
+        card = "JK"
+
+    if card:
+        return f"{card} {participant.name}"
+    return participant.name
 
 
-def send_match_confirmed_line_notifications(match_session, match_count):
+def _participant_id(participant_or_id):
+    return getattr(participant_or_id, "id", participant_or_id)
+
+
+def build_personal_match_notification_message(
+    participant, matches, bench, match_count, result_url
+):
+    participant_id = _participant_id(participant)
+    for court_index, match in enumerate(matches, start=1):
+        court_number = getattr(match, "court_number", court_index)
+        if hasattr(match, "team1_player1_id"):
+            team1 = [match.team1_player1, match.team1_player2]
+            team2 = [match.team2_player1, match.team2_player2]
+        else:
+            team1 = list(match[:2])
+            team2 = list(match[2:4])
+
+        match_participant_ids = [_participant_id(player) for player in team1 + team2]
+        if participant_id not in match_participant_ids:
+            continue
+
+        team1_text = "・".join(format_line_participant_label(player) for player in team1)
+        team2_text = "・".join(format_line_participant_label(player) for player in team2)
+        return (
+            f"第{match_count}回目\n\n"
+            f"あなたは {court_number}コートです\n\n"
+            f"{team1_text}\n"
+            "vs\n"
+            f"{team2_text}\n\n"
+            "結果はこちら\n"
+            f"{result_url}"
+        )
+
+    bench_participant_ids = {_participant_id(bench_player) for bench_player in bench}
+    if participant_id in bench_participant_ids:
+        return (
+            f"第{match_count}回目\n\n"
+            "今回は待機です。\n"
+            "次の組み合わせまでお待ちください。\n\n"
+            "結果はこちら\n"
+            f"{result_url}"
+        )
+
+    return None
+
+
+def build_personal_match_notification_context(matches, bench):
+    participant_ids = {pid for match in matches for pid in match}
+    participant_ids.update(bench)
+    participants_by_id = {
+        participant.id: participant
+        for participant in Participant.query.filter(Participant.id.in_(participant_ids)).all()
+    }
+    message_matches = [
+        [participants_by_id.get(participant_id) for participant_id in match]
+        for match in matches
+    ]
+    message_bench = [participants_by_id.get(participant_id) for participant_id in bench]
+    return message_matches, message_bench
+
+
+def send_match_confirmed_line_notifications(match_session, match_count, matches=None, bench=None):
     """Send confirmed-match LINE notifications once per match count and channel."""
     if match_session is None:
         return False
@@ -480,13 +545,25 @@ def send_match_confirmed_line_notifications(match_session, match_count):
         db.session.rollback()
         return False
 
-    message = build_match_confirmed_line_message()
+    if matches is None or bench is None:
+        state = load_match_state()
+        matches = state.get("matches", [])
+        bench = state.get("bench", [])
+    message_matches, message_bench = build_personal_match_notification_context(matches, bench)
+    result_url = url_for("match_result", _external=True)
     logs_by_participant_id = {
         log.participant_id: log for log, _participant in delivery_logs
     }
     for participant, line_account in targets:
         delivery_log = logs_by_participant_id[participant.id]
         delivery_log.sent_at = utc_now()
+        message = build_personal_match_notification_message(
+            participant, message_matches, message_bench, match_count, result_url
+        )
+        if message is None:
+            delivery_log.status = "skipped"
+            delivery_log.error_message = "participant not found in confirmed matches or bench"
+            continue
         try:
             push_line_message(line_account.line_user_id, message)
             delivery_log.status = "success"
@@ -1231,7 +1308,7 @@ def confirm_match():
         current_session.status = "confirmed"
         if current_session.confirmed_at is None:
             current_session.confirmed_at = utc_now()
-        send_match_confirmed_line_notifications(current_session, match_count)
+        send_match_confirmed_line_notifications(current_session, match_count, match_ids, bench_ids)
 
         db.session.commit()
     except Exception:

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1786,6 +1786,92 @@ def prepare_confirm_with_session(app_module, tmp_path, matches=None, bench=None)
     return participants, current_session, past_session
 
 
+
+def test_build_personal_match_notification_message_for_team1_team2_and_bench(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    with app_module.app.app_context():
+        players = [
+            app_module.Participant(name="田中", gender="male", level="beginner", weight=1.0, card="♥A"),
+            app_module.Participant(name="佐藤", gender="male", level="beginner", weight=1.0, card="♠3"),
+            app_module.Participant(name="山田", gender="female", level="beginner", weight=1.0, card=""),
+            app_module.Participant(name="鈴木", gender="female", level="beginner", weight=1.0, card="♣2"),
+            app_module.Participant(name="待機", gender="male", level="beginner", weight=1.0, card="JK"),
+        ]
+        app_module.db.session.add_all(players)
+        app_module.db.session.commit()
+        result_url = "https://example.com/match/result"
+        matches = [[players[0], players[1], players[2], players[3]]]
+
+        team1_message = app_module.build_personal_match_notification_message(
+            players[0], matches, [players[4]], 2, result_url
+        )
+        team2_message = app_module.build_personal_match_notification_message(
+            players[2], matches, [players[4]], 2, result_url
+        )
+        bench_message = app_module.build_personal_match_notification_message(
+            players[4], matches, [players[4]], 2, result_url
+        )
+
+        assert "第2回目" in team1_message
+        assert "あなたは 1コートです" in team1_message
+        assert "♥A 田中・♠3 佐藤" in team1_message
+        assert "山田・♣2 鈴木" in team1_message
+        assert result_url in team1_message
+        assert team2_message == team1_message
+        assert "今回は待機です。" in bench_message
+        assert result_url in bench_message
+
+
+def test_confirm_match_sends_different_court_messages_and_bench_message(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    sent = []
+    monkeypatch.setattr(app_module, "push_line_message", lambda user_id, text: sent.append((user_id, text)))
+
+    with app_module.app.app_context():
+        participants, current_session, _ = prepare_confirm_with_session(
+            app_module, tmp_path, matches=[[1, 2, 3, 4], [5, 6, 7, 8]], bench=[9]
+        )
+        add_line_subscription(app_module, current_session.id, participants[0], user_id="U-court-1")
+        add_line_subscription(app_module, current_session.id, participants[4], user_id="U-court-2")
+        add_line_subscription(app_module, current_session.id, participants[8], user_id="U-bench")
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post("/match/confirm")
+
+        assert response.status_code == 302
+        messages = dict(sent)
+        assert "あなたは 1コートです" in messages["U-court-1"]
+        assert "C1 player-1・C2 player-2" in messages["U-court-1"]
+        assert "あなたは 2コートです" in messages["U-court-2"]
+        assert "C5 player-5・C6 player-6" in messages["U-court-2"]
+        assert "今回は待機です。" in messages["U-bench"]
+        assert all("http://localhost/match/result" in message for message in messages.values())
+
+
+def test_confirm_match_skips_target_missing_from_matches_and_bench(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    sent = []
+    monkeypatch.setattr(app_module, "push_line_message", lambda user_id, text: sent.append(user_id))
+
+    with app_module.app.app_context():
+        participants, current_session, _ = prepare_confirm_with_session(app_module, tmp_path)
+        missing_participant = app_module.Participant(
+            name="missing", gender="male", level="beginner", weight=1.0, card="C5"
+        )
+        app_module.db.session.add(missing_participant)
+        app_module.db.session.flush()
+        add_line_subscription(app_module, current_session.id, missing_participant, user_id="U-missing")
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post("/match/confirm")
+
+        assert response.status_code == 302
+        assert sent == []
+        log = app_module.NotificationDeliveryLog.query.one()
+        assert log.status == "skipped"
+        assert "not found" in log.error_message
+
 def test_confirm_match_pushes_only_current_active_line_subscribers(monkeypatch, tmp_path):
     app_module = load_history_test_app(monkeypatch, tmp_path)
     sent = []
@@ -1806,8 +1892,12 @@ def test_confirm_match_pushes_only_current_active_line_subscribers(monkeypatch, 
 
         assert response.status_code == 302
         assert [user_id for user_id, _ in sent] == ["U-current"]
-        assert "組み合わせが確定しました" in sent[0][1]
-        assert "/match/result" in sent[0][1]
+        assert "第1回目" in sent[0][1]
+        assert "あなたは 1コートです" in sent[0][1]
+        assert "C1 player-1・C2 player-2" in sent[0][1]
+        assert "vs" in sent[0][1]
+        assert "C3 player-3・C4 player-4" in sent[0][1]
+        assert "http://localhost/match/result" in sent[0][1]
         logs = app_module.NotificationDeliveryLog.query.all()
         assert len(logs) == 1
         assert logs[0].session_id == current_session.id


### PR DESCRIPTION
### Motivation
- Replace the global/one-size LINE push sent on match confirm with per-participant messages that tell each player their court number and court members, and notify bench players they are waiting. 
- Preserve existing notification semantics such as session-scoped subscriptions, duplicate prevention via `MatchNotification(session_id, match_count, channel)`, `NotificationDeliveryLog.match_count`, and partial-failure handling.

### Description
- Added helper `format_line_participant_label` to render card + name (handles JOKER → `JK` and missing-card cases) and `_participant_id` to normalize id handling. 
- Implemented `build_personal_match_notification_message(participant, matches, bench, match_count, result_url)` that builds the required per-participant message for team1/team2 members, bench players, or returns `None` when participant is not found. 
- Added `build_personal_match_notification_context(matches, bench)` to resolve participant objects for message generation and adapted `send_match_confirmed_line_notifications` to accept `matches` and `bench`, generate per-participant messages, mark delivery logs as `skipped` when participant is not present, and otherwise push personalized messages using the existing `push_line_message`. 
- Changed confirm flow to pass the just-confirmed `match_ids` and `bench_ids` into the notification sender so the messages reflect the confirmed draft data.

### Testing
- Added unit tests covering `build_personal_match_notification_message` and end-to-end confirmation push behavior (per-court messages, bench messages, skipped/missing participants, per-match_count repeated sends). 
- Ran the full test suite with `pytest` and the modified tests; all tests passed (`247 passed`). 
- Ran repository checks including `git diff --check`; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4b400cac8333ad556d7f81e0fda7)