### PR TITLE
PayPayリンクの期限切れ警告を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,21 @@ export SECRET_KEY='replace-with-a-long-random-secret'
 
 ```json
 {
+  "paypay_links": {
+    "adults": "https://example.com/pay/adults",
+    "students": "https://example.com/pay/students"
+  },
+  "paypay_link_expirations": {
+    "adults": "2026-07-25",
+    "students": "2026-07-25"
+  },
   "score_input_mode": "winner_only",
   "consecutive_play_limit": 3
 }
 ```
 
+- `paypay_links`: 社会人用・学生用の PayPay 支払いリンクです。
+- `paypay_link_expirations`: PayPay 支払いリンクの有効期限です。`YYYY-MM-DD` 形式で指定します。URL が設定されている場合、期限の前日以降に管理者トップで警告します。未設定でも起動できます。
 - `score_input_mode`: 勝敗・スコア入力方式です。`winner_only` または `score` を指定します。
 - `consecutive_play_limit`: 何回連続出場したら次回ベンチ優先対象にするかを指定します。未設定時は `3` として扱います。設定範囲は `2` 〜 `10` で、`/admin/settings` から変更できます。
 
@@ -296,6 +306,7 @@ v1.4.0 では、組み合わせ確定後の履歴管理が強化されていま�
 
 `/admin/settings` では、ローカル設定ファイル `config.json` の一部をブラウザ上で変更できます。
 
+- PayPay リンクと有効期限 (`paypay_links`, `paypay_link_expirations`)
 - スコア入力モード (`score_input_mode`)
 - score モード用のスコア設定
 - 連続出場ベンチ優先回数 (`consecutive_play_limit`)

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import re
 import secrets
 import string
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from io import TextIOWrapper
 from flask import Flask, render_template, request, redirect, url_for, abort, jsonify
 from models import (
@@ -184,6 +185,15 @@ def normalize_scoring_system(value):
     }
 
 
+def normalize_paypay_link_expirations(value):
+    if not isinstance(value, dict):
+        value = {}
+    return {
+        "adults": value.get("adults") or "",
+        "students": value.get("students") or "",
+    }
+
+
 def normalize_config(config):
     if not isinstance(config, dict):
         config = {}
@@ -194,10 +204,73 @@ def normalize_config(config):
         config.get("consecutive_play_limit")
     )
     normalized.setdefault("paypay_links", {})
+    normalized["paypay_link_expirations"] = normalize_paypay_link_expirations(
+        config.get("paypay_link_expirations")
+    )
     normalized.setdefault("level_map", {})
     normalized.setdefault("gender_weight", {})
     return normalized
 
+
+PAYPAY_LINK_LABELS = {
+    "adults": "社会人用",
+    "students": "学生用",
+}
+TOKYO_TZ = ZoneInfo("Asia/Tokyo")
+
+
+def get_tokyo_today():
+    return datetime.now(TOKYO_TZ).date()
+
+
+def format_japanese_date(value):
+    return f"{value.year}年{value.month}月{value.day}日"
+
+
+def build_paypay_expiration_warnings(config, today=None):
+    paypay_links = config.get("paypay_links", {})
+    expirations = config.get("paypay_link_expirations", {})
+    if not isinstance(paypay_links, dict):
+        paypay_links = {}
+    if not isinstance(expirations, dict):
+        expirations = {}
+
+    today = today or get_tokyo_today()
+    warnings = []
+    for key, label in PAYPAY_LINK_LABELS.items():
+        url = (paypay_links.get(key) or "").strip()
+        if not url:
+            continue
+
+        expiration_text = (expirations.get(key) or "").strip()
+        if not expiration_text:
+            warnings.append({
+                "level": "warning",
+                "message": f"⚠️ {label}PayPayリンクの有効期限が設定されていません",
+            })
+            continue
+
+        try:
+            expiration_date = datetime.strptime(expiration_text, "%Y-%m-%d").date()
+        except ValueError:
+            warnings.append({
+                "level": "warning",
+                "message": f"⚠️ {label}PayPayリンクの有効期限が設定されていません",
+            })
+            continue
+
+        days_until_expiration = (expiration_date - today).days
+        formatted_date = format_japanese_date(expiration_date)
+        if days_until_expiration == 1:
+            message = f"⚠️ {label}PayPayリンクは明日（{formatted_date}）期限切れになります"
+        elif days_until_expiration == 0:
+            message = f"⚠️ {label}PayPayリンクは本日（{formatted_date}）期限切れになります"
+        elif days_until_expiration < 0:
+            message = f"🚨 {label}PayPayリンクは期限切れです（{formatted_date}）"
+        else:
+            continue
+        warnings.append({"level": "expired" if days_until_expiration < 0 else "warning", "message": message})
+    return warnings
 
 def load_config():
     with open('config.json', 'r', encoding='utf-8') as f:
@@ -295,7 +368,8 @@ def render_index_view(mode='viewer'):
         has_confirmed=has_confirmed,
         mode=mode,
         is_match_active=is_match_active,
-        max_rows=max_rows
+        max_rows=max_rows,
+        paypay_expiration_warnings=build_paypay_expiration_warnings(load_config()) if mode == 'admin' else []
     )
 
 @app.route('/')
@@ -1502,10 +1576,15 @@ def admin_settings():
     current_config = load_config()
     if request.method == 'POST':
         # configの保存処理
-        config = {
+        config = dict(current_config)
+        config.update({
             "paypay_links": {
                 "adults": request.form.get('paypay_adults'),
                 "students": request.form.get('paypay_students')
+            },
+            "paypay_link_expirations": {
+                "adults": request.form.get('paypay_expiration_adults') or "",
+                "students": request.form.get('paypay_expiration_students') or "",
             },
             "level_map": {
                 "beginner": parse_positive_int(request.form.get('level_beginner'), current_config["level_map"].get("beginner", 1)),
@@ -1526,7 +1605,7 @@ def admin_settings():
                 "deuce_enabled": request.form.get('deuce_enabled'),
                 "max_points": request.form.get('max_points'),
             }),
-        }
+        })
         with open('config.json', 'w', encoding='utf-8') as f:
             json.dump(config, f, indent=4, ensure_ascii=False)
         flash('設定を保存しました')

--- a/config.example.json
+++ b/config.example.json
@@ -19,5 +19,9 @@
     "deuce_enabled": false,
     "max_points": 21
   },
-  "consecutive_play_limit": 3
+  "consecutive_play_limit": 3,
+  "paypay_link_expirations": {
+    "adults": "2026-07-25",
+    "students": "2026-07-25"
+  }
 }

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -13,8 +13,14 @@
     <label>社会人リンク</label>
     <input type="text" name="paypay_adults" value="{{ config.paypay_links.adults }}">
     <br>
+    <label>社会人リンクの有効期限</label>
+    <input type="date" name="paypay_expiration_adults" value="{{ config.paypay_link_expirations.adults }}">
+    <br>
     <label>学生リンク</label>
     <input type="text" name="paypay_students" value="{{ config.paypay_links.students }}">
+    <br>
+    <label>学生リンクの有効期限</label>
+    <input type="date" name="paypay_expiration_students" value="{{ config.paypay_link_expirations.students }}">
     <hr>
 
     <h3>競技レベルマッピング</h3>

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,6 +175,17 @@
         </table>
     </div>
 
+    {% if mode == 'admin' and paypay_expiration_warnings %}
+        <section class="admin-warning-list">
+            {% for warning in paypay_expiration_warnings %}
+                <p class="admin-warning {{ warning.level }}">
+                    {{ warning.message }}
+                    <a href="{{ url_for('admin_settings') }}">設定を確認する</a>
+                </p>
+            {% endfor %}
+        </section>
+    {% endif %}
+
     <nav class="button-row">
         {% if mode == 'admin' %}
             <a href="{{ url_for('admin_settings') }}" class="btn btn-secondary">⚙️ 設定</a>

--- a/tests/test_paypay_expiration.py
+++ b/tests/test_paypay_expiration.py
@@ -1,0 +1,123 @@
+import importlib
+import json
+import os
+import sys
+from datetime import date
+from types import SimpleNamespace
+
+
+def import_app(monkeypatch, tmp_path, config):
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.setenv("ALLOW_DEV_SECRET_KEY", "1")
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    app_module.app.config.update(TESTING=True)
+    return app_module
+
+
+def stub_index_dependencies(monkeypatch, app_module):
+    monkeypatch.setattr(app_module, "generate_card_layout", lambda participants: ({}, {"♠": [], "♥": [], "♦": [], "♣": []}))
+    monkeypatch.setattr(app_module, "get_active_draft", lambda: None)
+    monkeypatch.setattr(app_module, "load_match_state", lambda: {"matches": [], "bench": [], "match_active": False, "match_count": 0})
+    monkeypatch.setattr(app_module, "Participant", SimpleNamespace(query=SimpleNamespace(order_by=lambda field: SimpleNamespace(all=lambda: [])), card=None))
+
+
+def paypay_config(expiration):
+    return {
+        "paypay_links": {"adults": "https://example.com/adults", "students": ""},
+        "paypay_link_expirations": {"adults": expiration, "students": ""},
+        "level_map": {},
+        "gender_weight": {},
+    }
+
+
+def test_paypay_warning_not_shown_two_days_before(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config("2026-07-25"))
+
+    warnings = app_module.build_paypay_expiration_warnings(app_module.load_config(), today=date(2026, 7, 23))
+
+    assert warnings == []
+
+
+def test_paypay_warning_shown_day_before(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config("2026-07-25"))
+
+    warnings = app_module.build_paypay_expiration_warnings(app_module.load_config(), today=date(2026, 7, 24))
+
+    assert warnings[0]["message"] == "⚠️ 社会人用PayPayリンクは明日（2026年7月25日）期限切れになります"
+
+
+def test_paypay_warning_shown_on_expiration_day(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config("2026-07-25"))
+
+    warnings = app_module.build_paypay_expiration_warnings(app_module.load_config(), today=date(2026, 7, 25))
+
+    assert warnings[0]["message"] == "⚠️ 社会人用PayPayリンクは本日（2026年7月25日）期限切れになります"
+
+
+def test_paypay_warning_shown_after_expiration(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config("2026-07-25"))
+
+    warnings = app_module.build_paypay_expiration_warnings(app_module.load_config(), today=date(2026, 7, 26))
+
+    assert warnings[0]["message"] == "🚨 社会人用PayPayリンクは期限切れです（2026年7月25日）"
+
+
+def test_paypay_warning_shown_when_url_has_no_expiration(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config(""))
+
+    warnings = app_module.build_paypay_expiration_warnings(app_module.load_config(), today=date(2026, 7, 24))
+
+    assert warnings[0]["message"] == "⚠️ 社会人用PayPayリンクの有効期限が設定されていません"
+
+
+def test_paypay_warning_not_shown_in_viewer_mode(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, paypay_config("2026-07-25"))
+    monkeypatch.setattr(app_module, "get_tokyo_today", lambda: date(2026, 7, 24))
+    stub_index_dependencies(monkeypatch, app_module)
+
+    html = app_module.app.test_client().get("/viewer").get_data(as_text=True)
+
+    assert "PayPayリンクは明日" not in html
+
+
+def test_old_config_loads_without_paypay_expirations(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, {"paypay_links": {"adults": "https://example.com/adults"}})
+
+    config = app_module.load_config()
+
+    assert config["paypay_link_expirations"] == {"adults": "", "students": ""}
+
+
+def test_admin_settings_saves_expiration_dates_and_preserves_existing_settings(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, {
+        "paypay_links": {"adults": "old-adults", "students": "old-students"},
+        "paypay_link_expirations": {"adults": "", "students": ""},
+        "level_map": {"beginner": 1, "intermediate": 2, "advanced": 3},
+        "gender_weight": {"male": 1.0, "female": 0.9},
+        "custom_setting": {"kept": True},
+    })
+
+    response = app_module.app.test_client().post("/admin/settings", data={
+        "paypay_adults": "adults",
+        "paypay_students": "students",
+        "paypay_expiration_adults": "2026-07-25",
+        "paypay_expiration_students": "2026-07-26",
+        "level_beginner": "1",
+        "level_intermediate": "2",
+        "level_advanced": "3",
+        "weight_male": "1.0",
+        "weight_female": "0.9",
+        "score_input_mode": "winner_only",
+        "consecutive_play_limit": "3",
+        "points_per_game": "21",
+        "games_per_match": "1",
+        "max_points": "21",
+    })
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["paypay_link_expirations"] == {"adults": "2026-07-25", "students": "2026-07-26"}
+    assert saved["custom_setting"] == {"kept": True}


### PR DESCRIPTION
### Motivation
- 管理者が設定した PayPay 支払いリンクの有効期限を監視し、期限前日・当日・期限切れを管理者トップで通知することで支払いリンクの更新忘れを防止するため。 
- 日本時間（`Asia/Tokyo`）基準で判定し、OS のタイムゾーンに依存しないようにするため。 
- 既存の `paypay_links` 形式や他の管理者設定を壊さず後方互換性を保つため。 

### Description
- 新しい設定キー `paypay_link_expirations` を正規化する `normalize_paypay_link_expirations` を追加し、`normalize_config` に組み込みました（`adults` / `students` を空文字で補完）。
- 日本時間判定を行う `TOKYO_TZ` / `get_tokyo_today()`、表示用フォーマット `format_japanese_date()`、警告データを生成する `build_paypay_expiration_warnings(config, today=None)` を追加しました。 
- 管理者トップ用のビュー生成でのみ `paypay_expiration_warnings` をテンプレートに渡すようにし、参加者向け表示（`/viewer`）には渡さないようにしました（`render_index_view` の変更）。
- `/admin/settings` の保存処理を `current_config` をベースに `config.update({...})` する方式に変更し、`paypay_link_expirations`（`paypay_expiration_adults` / `paypay_expiration_students`）を保存するようにしました。これにより既存の未知キーを保持します。 
- 管理者設定テンプレート `templates/admin_settings.html` に `input type="date"` の有効期限フィールドを追加しました（`paypay_expiration_adults` / `paypay_expiration_students`）。
- 管理者トップ（`templates/index.html`）に警告表示領域を追加し、警告文中に `admin_settings` へのリンクを付与しました。 
- ドキュメントの例 `config.example.json` と `README.md` を更新して新設定を記載しました。 
- 自動テスト `tests/test_paypay_expiration.py` を追加し、警告ロジック、ビュー表示、古い config 互換性、管理者設定保存の動作を検証しました。 

### Testing
- `pytest tests/test_paypay_expiration.py` を実行し `8 passed` で成功しました. 
- リポジトリ全体の `pytest` を実行し `255 passed` で成功しました. 
- 開発サーバーを `ALLOW_DEV_SECRET_KEY=1 python app.py` で起動して手動確認し、`/admin` に警告が表示されることと `/viewer` には表示されないことを確認しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51df0d7f748333ab79973ca72af893)