### PR TITLE
履歴ダンプのSMTPメール送信機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,62 @@ player_score = level_score * weight + win_rate
 - `instance/history_dumps/` は Git 管理対象外です。
 - ダンプ JSON には、ラウンド、試合、ベンチ、参加者名、カード、スコア、勝敗などが含まれます。
 
+
+### SMTPメール送信
+
+`/admin/settings` では、試合履歴JSONダンプをローカル保存後にメール添付で送信するかを設定できます。送信方式はAmazon SES APIやOSの `sendmail` / `mail` / Postfix には依存しない標準SMTPです。同じPythonコードをAmazon EC2上のUbuntu、一般的なUbuntu、macOSで利用できます。
+
+`config.json` には有効/無効と送信先だけを保存します。SMTPホスト、ユーザー名、パスワードなどの接続情報は環境変数から読み込み、パスワードを `config.json` へ保存しません。Gmail、Amazon SES SMTP、社内SMTPリレーなど、任意のSMTPサービスへ環境変数の切り替えだけで接続先を変更できます。
+
+必要な環境変数は次のとおりです。
+
+| 環境変数 | 内容 |
+| --- | --- |
+| `SMTP_HOST` | SMTPサーバーのホスト名（必須） |
+| `SMTP_PORT` | SMTPポート。未設定時はSSLが465、それ以外は587 |
+| `SMTP_SECURITY` | `starttls`、`ssl`、`none` のいずれか |
+| `SMTP_USERNAME` | SMTPユーザー名。空なら認証しません |
+| `SMTP_PASSWORD` | SMTPパスワード |
+| `SMTP_FROM_EMAIL` | Fromメールアドレス（必須） |
+| `SMTP_FROM_NAME` | From表示名 |
+| `SMTP_TIMEOUT_SECONDS` | SMTP接続タイムアウト秒数。未設定時は約10秒 |
+
+STARTTLS（通常587番）の例:
+
+```bash
+export SMTP_HOST=smtp.example.com
+export SMTP_PORT=587
+export SMTP_SECURITY=starttls
+export SMTP_USERNAME=your-smtp-user
+export SMTP_PASSWORD=your-smtp-password
+export SMTP_FROM_EMAIL=no-reply@example.com
+export SMTP_FROM_NAME="Shuttlers Match App"
+```
+
+SSL/TLS（通常465番）の例:
+
+```bash
+export SMTP_HOST=smtp.example.com
+export SMTP_PORT=465
+export SMTP_SECURITY=ssl
+export SMTP_USERNAME=your-smtp-user
+export SMTP_PASSWORD=your-smtp-password
+export SMTP_FROM_EMAIL=no-reply@example.com
+```
+
+認証なしローカルSMTPリレーの例:
+
+```bash
+export SMTP_HOST=localhost
+export SMTP_PORT=25
+export SMTP_SECURITY=none
+export SMTP_FROM_EMAIL=no-reply@example.com
+unset SMTP_USERNAME
+unset SMTP_PASSWORD
+```
+
+メール送信が有効な場合、手動の「履歴をJSONダンプ」はメールに失敗してもJSON保存済みとして扱います。「履歴を削除してダンプ」と「全データ削除」前の自動ダンプでは、メール送信に失敗するとDB削除を中止し、保存済みJSONは残します。
+
 ### ダンプ済み履歴表示
 
 - `/admin/match_history_archives` でダンプ済み履歴一覧を確認できます。

--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ from utils.stats import calculate_participant_win_stats
 from utils.reset import reset_match_state
 from utils.match_session import ensure_current_match_session
 from utils.line_push import push_line_message
+from utils.mail_sender import send_email_with_attachment
 from routes.api import api_bp
 
 app = Flask(__name__, instance_relative_config=True)
@@ -185,6 +186,15 @@ def normalize_scoring_system(value):
     }
 
 
+def normalize_history_dump_email(value):
+    if not isinstance(value, dict):
+        value = {}
+    return {
+        "enabled": parse_bool(value.get("enabled"), False),
+        "recipient": (value.get("recipient") or "").strip(),
+    }
+
+
 def normalize_paypay_link_expirations(value):
     if not isinstance(value, dict):
         value = {}
@@ -206,6 +216,9 @@ def normalize_config(config):
     normalized.setdefault("paypay_links", {})
     normalized["paypay_link_expirations"] = normalize_paypay_link_expirations(
         config.get("paypay_link_expirations")
+    )
+    normalized["history_dump_email"] = normalize_history_dump_email(
+        config.get("history_dump_email")
     )
     normalized.setdefault("level_map", {})
     normalized.setdefault("gender_weight", {})
@@ -1577,6 +1590,12 @@ def admin_settings():
     if request.method == 'POST':
         # configの保存処理
         config = dict(current_config)
+        history_dump_email_enabled = parse_bool(request.form.get('history_dump_email_enabled'))
+        history_dump_email_recipient = (request.form.get('history_dump_email_recipient') or '').strip()
+        if history_dump_email_enabled and not history_dump_email_recipient:
+            flash('履歴ダンプのメール送信を有効にする場合は、送信先メールアドレスを入力してください')
+            return render_template('admin_settings.html', config=current_config)
+
         config.update({
             "paypay_links": {
                 "adults": request.form.get('paypay_adults'),
@@ -1605,6 +1624,10 @@ def admin_settings():
                 "deuce_enabled": request.form.get('deuce_enabled'),
                 "max_points": request.form.get('max_points'),
             }),
+            "history_dump_email": {
+                "enabled": history_dump_email_enabled,
+                "recipient": history_dump_email_recipient,
+            },
         })
         with open('config.json', 'w', encoding='utf-8') as f:
             json.dump(config, f, indent=4, ensure_ascii=False)
@@ -1616,11 +1639,16 @@ def admin_settings():
 @app.route('/admin/reset_db', methods=['POST'])
 def reset_db():
     try:
-        dump_match_history_to_json('clear_all_data')
+        dump_path = dump_match_history_to_json('clear_all_data')
     except Exception:
         db.session.rollback()
         app.logger.exception('Failed to dump match history before clearing all data')
         flash('試合履歴のJSON保存に失敗したため、全データ削除を中止しました')
+        return redirect(url_for('admin_settings'))
+
+    if not send_history_dump_email_if_enabled(dump_path):
+        db.session.rollback()
+        flash('試合履歴をJSONに保存しましたが、メール送信に失敗したため、全データ削除を中止しました')
         return redirect(url_for('admin_settings'))
 
     # 先にマッチ状態をリセット
@@ -1872,6 +1900,51 @@ def dump_match_history_to_json(reason):
     with open(dump_path, 'w', encoding='utf-8') as dump_file:
         json.dump(dump_data, dump_file, indent=2, ensure_ascii=False)
     return dump_path
+
+
+def build_history_dump_email_body(dump_data, attachment_name):
+    rounds = dump_data.get("rounds") if isinstance(dump_data, dict) else []
+    if not isinstance(rounds, list):
+        rounds = []
+    round_count = len(rounds)
+    match_count = sum(len(round_data.get("matches", [])) for round_data in rounds if isinstance(round_data, dict))
+    bench_count = sum(len(round_data.get("bench", [])) for round_data in rounds if isinstance(round_data, dict))
+    return "\n".join([
+        "shuttlers-match-app の試合履歴ダンプを添付します。",
+        f"ダンプ作成日時: {dump_data.get('dumped_at')}",
+        f"ダンプ理由: {dump_data.get('reason')}",
+        f"添付ファイル名: {attachment_name}",
+        f"ラウンド数: {round_count}",
+        f"試合数: {match_count}",
+        f"待機履歴数: {bench_count}",
+    ])
+
+
+def send_history_dump_email_if_enabled(dump_path):
+    email_config = load_config().get("history_dump_email", {})
+    if not email_config.get("enabled"):
+        return True
+
+    recipient = (email_config.get("recipient") or "").strip()
+    if not recipient:
+        return True
+
+    try:
+        with open(dump_path, encoding='utf-8') as dump_file:
+            dump_data = json.load(dump_file)
+        attachment_name = os.path.basename(dump_path)
+        dumped_at = dump_data.get("dumped_at") or datetime.now(timezone.utc).isoformat()
+        subject_date = dumped_at[:10]
+        send_email_with_attachment(
+            recipient=recipient,
+            subject=f"shuttlers-match-app 試合履歴ダンプ {subject_date}",
+            body=build_history_dump_email_body(dump_data, attachment_name),
+            attachment_path=dump_path,
+        )
+    except Exception:
+        app.logger.exception('Failed to send match history dump email')
+        return False
+    return True
 
 
 def clear_match_history_records():
@@ -2197,6 +2270,10 @@ def dump_match_history():
         flash('試合履歴のJSON保存に失敗しました')
         return redirect(url_for('admin_match_history'))
 
+    if not send_history_dump_email_if_enabled(dump_path):
+        flash(f'試合履歴をJSONに保存しましたが、メール送信に失敗しました: {os.path.basename(dump_path)}')
+        return redirect(url_for('admin_match_history'))
+
     flash(f'試合履歴をJSONに保存しました: {os.path.basename(dump_path)}')
     return redirect(url_for('admin_match_history'))
 
@@ -2209,6 +2286,11 @@ def dump_and_clear_match_history():
         db.session.rollback()
         app.logger.exception('Failed to dump match history before clearing')
         flash('試合履歴のJSON保存に失敗したため、履歴消去を中止しました')
+        return redirect(url_for('admin_match_history'))
+
+    if not send_history_dump_email_if_enabled(dump_path):
+        db.session.rollback()
+        flash(f'試合履歴をJSONに保存しましたが、メール送信に失敗したため、履歴消去を中止しました: {os.path.basename(dump_path)}')
         return redirect(url_for('admin_match_history'))
 
     try:

--- a/config.example.json
+++ b/config.example.json
@@ -23,5 +23,9 @@
   "paypay_link_expirations": {
     "adults": "2026-07-25",
     "students": "2026-07-25"
+  },
+  "history_dump_email": {
+    "enabled": false,
+    "recipient": ""
   }
 }

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -48,6 +48,17 @@
     <p>指定回数以上連続で試合に入った参加者は、次回できる限りベンチに回します。推奨範囲: 2〜10</p>
     <hr>
 
+    <h3>履歴ダンプメール送信設定</h3>
+    <label>
+        <input type="checkbox" name="history_dump_email_enabled" value="on" {% if config.history_dump_email.enabled %}checked{% endif %}>
+        履歴ダンプをメール送信する
+    </label>
+    <br>
+    <label>送信先メールアドレス</label>
+    <input type="email" name="history_dump_email_recipient" value="{{ config.history_dump_email.recipient }}" placeholder="recipient@example.com">
+    <p>SMTP接続情報と認証情報は環境変数から取得します。パスワードはconfig.jsonへ保存しません。</p>
+    <hr>
+
     <h3>勝敗・スコア入力設定</h3>
     <label>勝敗・スコア入力モード</label>
     <select name="score_input_mode">

--- a/tests/test_mail_sender.py
+++ b/tests/test_mail_sender.py
@@ -1,0 +1,105 @@
+from email.message import EmailMessage
+
+import pytest
+
+from utils import mail_sender
+
+
+class DummySMTP:
+    instances = []
+
+    def __init__(self, host, port, timeout=None, **kwargs):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.kwargs = kwargs
+        self.started_tls = False
+        self.login_calls = []
+        self.sent_messages = []
+        DummySMTP.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self, context=None):
+        self.started_tls = True
+        self.tls_context = context
+
+    def login(self, username, password):
+        self.login_calls.append((username, password))
+
+    def send_message(self, message, from_addr=None, to_addrs=None):
+        self.sent_messages.append((message, from_addr, to_addrs))
+
+
+@pytest.fixture(autouse=True)
+def smtp_env(monkeypatch):
+    DummySMTP.instances = []
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_SECURITY", "starttls")
+    monkeypatch.setenv("SMTP_FROM_EMAIL", "sender@example.com")
+    monkeypatch.delenv("SMTP_USERNAME", raising=False)
+    monkeypatch.delenv("SMTP_PASSWORD", raising=False)
+    monkeypatch.setattr(mail_sender.smtplib, "SMTP", DummySMTP)
+    monkeypatch.setattr(mail_sender.smtplib, "SMTP_SSL", DummySMTP)
+
+
+def write_attachment(tmp_path):
+    attachment = tmp_path / "history.json"
+    attachment.write_text('{"ok": true}', encoding="utf-8")
+    return attachment
+
+
+def send(tmp_path):
+    mail_sender.send_email_with_attachment(
+        recipient="to@example.com",
+        subject="subject",
+        body="body",
+        attachment_path=write_attachment(tmp_path),
+    )
+    return DummySMTP.instances[-1]
+
+
+def test_starttls_connection(monkeypatch, tmp_path):
+    smtp = send(tmp_path)
+    assert smtp.host == "smtp.example.com"
+    assert smtp.port == 2525
+    assert smtp.started_tls is True
+
+
+def test_ssl_connection(monkeypatch, tmp_path):
+    monkeypatch.setenv("SMTP_SECURITY", "ssl")
+    smtp = send(tmp_path)
+    assert smtp.started_tls is False
+    assert "context" in smtp.kwargs
+
+
+def test_none_connection(monkeypatch, tmp_path):
+    monkeypatch.setenv("SMTP_SECURITY", "none")
+    smtp = send(tmp_path)
+    assert smtp.started_tls is False
+
+
+def test_login_when_credentials_present(monkeypatch, tmp_path):
+    monkeypatch.setenv("SMTP_USERNAME", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "secret")
+    smtp = send(tmp_path)
+    assert smtp.login_calls == [("user", "secret")]
+
+
+def test_does_not_login_without_username(tmp_path):
+    smtp = send(tmp_path)
+    assert smtp.login_calls == []
+
+
+def test_json_file_is_attached_with_original_filename(tmp_path):
+    smtp = send(tmp_path)
+    message = smtp.sent_messages[0][0]
+    attachments = list(message.iter_attachments())
+    assert len(attachments) == 1
+    assert attachments[0].get_filename() == "history.json"
+    assert attachments[0].get_content_type() == "application/json"

--- a/tests/test_mail_sender.py
+++ b/tests/test_mail_sender.py
@@ -96,6 +96,39 @@ def test_does_not_login_without_username(tmp_path):
     assert smtp.login_calls == []
 
 
+def test_missing_password_with_username_raises_configuration_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("SMTP_USERNAME", "user")
+    monkeypatch.delenv("SMTP_PASSWORD", raising=False)
+
+    with pytest.raises(
+        mail_sender.MailConfigurationError,
+        match="SMTP_PASSWORD is required when SMTP_USERNAME is set",
+    ):
+        mail_sender.send_email_with_attachment(
+            recipient="to@example.com",
+            subject="subject",
+            body="body",
+            attachment_path=write_attachment(tmp_path),
+        )
+
+    assert DummySMTP.instances == []
+
+
+def test_empty_password_with_username_raises_configuration_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("SMTP_USERNAME", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "")
+
+    with pytest.raises(mail_sender.MailConfigurationError):
+        mail_sender.send_email_with_attachment(
+            recipient="to@example.com",
+            subject="subject",
+            body="body",
+            attachment_path=write_attachment(tmp_path),
+        )
+
+    assert DummySMTP.instances == []
+
+
 def test_json_file_is_attached_with_original_filename(tmp_path):
     smtp = send(tmp_path)
     message = smtp.sent_messages[0][0]

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -2060,3 +2060,110 @@ def test_confirm_match_without_line_token_creates_failed_log(monkeypatch, tmp_pa
         notification = app_module.MatchNotification.query.one()
         assert notification.status == "completed"
         assert notification.sent_at is not None
+
+
+def set_history_dump_email_config(tmp_path, enabled=True, recipient="dump@example.com"):
+    config_path = tmp_path / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["history_dump_email"] = {"enabled": enabled, "recipient": recipient}
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def add_confirmed_history(app_module, tmp_path):
+    write_draft(tmp_path, [[1, 2, 3, 4]], [5])
+    add_participants(app_module, 5)
+    app_module.app.test_client().post("/match/confirm")
+
+
+def test_email_disabled_does_not_call_sender(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: calls.append(kwargs))
+    dump_path = tmp_path / "dump.json"
+    dump_path.write_text(json.dumps({"rounds": []}), encoding="utf-8")
+    assert app_module.send_history_dump_email_if_enabled(dump_path) is True
+    assert calls == []
+
+
+def test_empty_recipient_does_not_call_sender(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    set_history_dump_email_config(tmp_path, enabled=True, recipient="")
+    calls = []
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: calls.append(kwargs))
+    dump_path = tmp_path / "dump.json"
+    dump_path.write_text(json.dumps({"rounds": []}), encoding="utf-8")
+    assert app_module.send_history_dump_email_if_enabled(dump_path) is True
+    assert calls == []
+
+
+def test_manual_dump_success_sends_email(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    set_history_dump_email_config(tmp_path)
+    calls = []
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: calls.append(kwargs))
+    with app_module.app.app_context():
+        add_confirmed_history(app_module, tmp_path)
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+    assert response.status_code == 302
+    assert len(calls) == 1
+    assert calls[0]["recipient"] == "dump@example.com"
+    assert Path(calls[0]["attachment_path"]).exists()
+    assert "ラウンド数: 1" in calls[0]["body"]
+    assert "試合数: 1" in calls[0]["body"]
+    assert "待機履歴数: 1" in calls[0]["body"]
+
+
+def test_manual_dump_email_failure_keeps_json(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    set_history_dump_email_config(tmp_path)
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("smtp failed")))
+    with app_module.app.app_context():
+        add_confirmed_history(app_module, tmp_path)
+        response = app_module.app.test_client().post("/admin/match_history/dump")
+    assert response.status_code == 302
+    dumps = list((Path(app_module.app.instance_path) / "history_dumps").glob("match_history_manual_dump_*.json"))
+    assert dumps
+
+
+def test_dump_and_clear_email_failure_does_not_delete_history(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    set_history_dump_email_config(tmp_path)
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("smtp failed")))
+    with app_module.app.app_context():
+        add_confirmed_history(app_module, tmp_path)
+        response = app_module.app.test_client().post("/admin/match_history/dump_and_clear")
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.BenchHistory.query.count() == 1
+
+
+def test_reset_db_email_failure_aborts_delete(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    set_history_dump_email_config(tmp_path)
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("smtp failed")))
+    with app_module.app.app_context():
+        add_confirmed_history(app_module, tmp_path)
+        response = app_module.app.test_client().post("/admin/reset_db")
+        assert response.status_code == 302
+        assert app_module.Participant.query.count() == 5
+        assert app_module.MatchHistory.query.count() == 1
+
+
+def test_dump_and_clear_email_disabled_keeps_existing_behavior(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(app_module, "send_email_with_attachment", lambda **kwargs: calls.append(kwargs))
+    with app_module.app.app_context():
+        add_confirmed_history(app_module, tmp_path)
+        response = app_module.app.test_client().post("/admin/match_history/dump_and_clear")
+        assert response.status_code == 302
+        assert calls == []
+        assert app_module.MatchHistory.query.count() == 0
+        assert app_module.MatchRound.query.count() == 0
+
+
+def test_old_config_loads_without_history_dump_email(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    config = app_module.load_config()
+    assert config["history_dump_email"] == {"enabled": False, "recipient": ""}

--- a/tests/test_paypay_expiration.py
+++ b/tests/test_paypay_expiration.py
@@ -121,3 +121,56 @@ def test_admin_settings_saves_expiration_dates_and_preserves_existing_settings(m
     saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
     assert saved["paypay_link_expirations"] == {"adults": "2026-07-25", "students": "2026-07-26"}
     assert saved["custom_setting"] == {"kept": True}
+
+
+def test_admin_settings_saves_history_dump_email_and_preserves_other_config(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, {
+        "paypay_links": {"adults": "old-adults", "students": "old-students"},
+        "paypay_link_expirations": {"adults": "2026-07-25", "students": "2026-07-26"},
+        "level_map": {"beginner": 1, "intermediate": 2, "advanced": 3},
+        "gender_weight": {"male": 1.0, "female": 0.9},
+        "history_dump_email": {"enabled": False, "recipient": ""},
+        "custom_setting": {"kept": True},
+    })
+
+    response = app_module.app.test_client().post("/admin/settings", data={
+        "paypay_adults": "adults",
+        "paypay_students": "students",
+        "paypay_expiration_adults": "2026-07-25",
+        "paypay_expiration_students": "2026-07-26",
+        "level_beginner": "1",
+        "level_intermediate": "2",
+        "level_advanced": "3",
+        "weight_male": "1.0",
+        "weight_female": "0.9",
+        "score_input_mode": "winner_only",
+        "consecutive_play_limit": "3",
+        "points_per_game": "21",
+        "games_per_match": "1",
+        "max_points": "21",
+        "history_dump_email_enabled": "on",
+        "history_dump_email_recipient": "dump@example.com",
+    })
+
+    assert response.status_code == 302
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["history_dump_email"] == {"enabled": True, "recipient": "dump@example.com"}
+    assert saved["paypay_link_expirations"] == {"adults": "2026-07-25", "students": "2026-07-26"}
+    assert saved["custom_setting"] == {"kept": True}
+
+
+def test_admin_settings_rejects_enabled_history_dump_email_without_recipient(monkeypatch, tmp_path):
+    app_module = import_app(monkeypatch, tmp_path, {
+        "paypay_links": {"adults": "old-adults", "students": "old-students"},
+        "level_map": {"beginner": 1, "intermediate": 2, "advanced": 3},
+        "gender_weight": {"male": 1.0, "female": 0.9},
+    })
+
+    response = app_module.app.test_client().post("/admin/settings", data={
+        "history_dump_email_enabled": "on",
+        "history_dump_email_recipient": "",
+    })
+
+    assert response.status_code == 200
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert "history_dump_email" not in saved

--- a/utils/mail_sender.py
+++ b/utils/mail_sender.py
@@ -81,6 +81,10 @@ def send_email_with_attachment(recipient, subject, body, attachment_path):
     message, from_email = _build_message(recipient, subject, body, attachment_path)
     username = os.environ.get("SMTP_USERNAME", "").strip()
     password = os.environ.get("SMTP_PASSWORD", "")
+    if username and not password:
+        raise MailConfigurationError(
+            "SMTP_PASSWORD is required when SMTP_USERNAME is set"
+        )
     context = ssl.create_default_context()
 
     if security == "ssl":

--- a/utils/mail_sender.py
+++ b/utils/mail_sender.py
@@ -1,0 +1,98 @@
+"""SMTP mail helpers for history dump delivery."""
+
+import mimetypes
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from pathlib import Path
+
+VALID_SMTP_SECURITY = {"starttls", "ssl", "none"}
+
+
+class MailConfigurationError(RuntimeError):
+    """Raised when required SMTP settings are missing or invalid."""
+
+
+def _get_required_env(name):
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise MailConfigurationError(f"{name} is required for SMTP email delivery")
+    return value
+
+
+def _get_smtp_port(security):
+    port_value = os.environ.get("SMTP_PORT", "").strip()
+    if port_value:
+        try:
+            return int(port_value)
+        except ValueError as exc:
+            raise MailConfigurationError("SMTP_PORT must be an integer") from exc
+    return 465 if security == "ssl" else 587
+
+
+def _get_timeout_seconds():
+    timeout_value = os.environ.get("SMTP_TIMEOUT_SECONDS", "").strip()
+    if not timeout_value:
+        return 10.0
+    try:
+        timeout = float(timeout_value)
+    except ValueError as exc:
+        raise MailConfigurationError("SMTP_TIMEOUT_SECONDS must be a number") from exc
+    if timeout <= 0:
+        raise MailConfigurationError("SMTP_TIMEOUT_SECONDS must be greater than 0")
+    return timeout
+
+
+def _build_message(recipient, subject, body, attachment_path):
+    from_email = _get_required_env("SMTP_FROM_EMAIL")
+    from_name = os.environ.get("SMTP_FROM_NAME", "").strip()
+    sender = f"{from_name} <{from_email}>" if from_name else from_email
+
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = recipient
+    message["Subject"] = subject
+    message.set_content(body)
+
+    path = Path(attachment_path)
+    content_type, _encoding = mimetypes.guess_type(str(path))
+    if content_type is None:
+        content_type = "application/octet-stream"
+    maintype, subtype = content_type.split("/", 1)
+    message.add_attachment(
+        path.read_bytes(),
+        maintype=maintype,
+        subtype=subtype,
+        filename=path.name,
+    )
+    return message, from_email
+
+
+def send_email_with_attachment(recipient, subject, body, attachment_path):
+    """Send an email with a single file attachment using direct SMTP."""
+    host = _get_required_env("SMTP_HOST")
+    security = os.environ.get("SMTP_SECURITY", "starttls").strip().lower() or "starttls"
+    if security not in VALID_SMTP_SECURITY:
+        raise MailConfigurationError("SMTP_SECURITY must be one of: starttls, ssl, none")
+
+    port = _get_smtp_port(security)
+    timeout = _get_timeout_seconds()
+    message, from_email = _build_message(recipient, subject, body, attachment_path)
+    username = os.environ.get("SMTP_USERNAME", "").strip()
+    password = os.environ.get("SMTP_PASSWORD", "")
+    context = ssl.create_default_context()
+
+    if security == "ssl":
+        smtp_factory = smtplib.SMTP_SSL
+        smtp_kwargs = {"context": context}
+    else:
+        smtp_factory = smtplib.SMTP
+        smtp_kwargs = {}
+
+    with smtp_factory(host, port, timeout=timeout, **smtp_kwargs) as smtp:
+        if security == "starttls":
+            smtp.starttls(context=context)
+        if username:
+            smtp.login(username, password)
+        smtp.send_message(message, from_addr=from_email, to_addrs=[recipient])


### PR DESCRIPTION
### Motivation

- 管理者が作成する試合履歴JSONダンプをローカル保存だけでなくメール添付で送信できるようにして、運用上のバックアップ手段を提供するため。 
- Amazon SESの専用APIやOSの`sendmail`等に依存せず、標準的なSMTP接続でEC2/Ubuntu/macOS上で同じ動作をさせるため。 

### Description

- 追加した`utils/mail_sender.py`に`send_email_with_attachment(recipient, subject, body, attachment_path)`を実装し、`smtplib`/`ssl`/`email.message.EmailMessage`/`mimetypes`を用いて`starttls`/`ssl`/`none`の各モード、認証あり/なし、添付ファイル名維持をサポートしました. 
- `app.py`に`history_dump_email`の正規化関数と管理画面での保存処理（宛先必須バリデーション）を追加し、`dump_match_history_to_json`経路・`dump_and_clear`・`reset_db`の各処理にメール送信呼び出しと失敗時の振る舞い（手動ダンプはJSONを残してflash、削除系はメール失敗で削除中止）を組み込みました。 
- 管理画面テンプレート`templates/admin_settings.html`に「履歴ダンプをメール送信する」チェックボックスと送信先入力を追加し、`config.example.json`に`history_dump_email`設定を追加しました。 
- 単体テストとして`tests/test_mail_sender.py`を追加し、メール送信ロジックをモックで検証するとともに`tests/test_match_history.py`と`tests/test_paypay_expiration.py`に管理画面やダンプ経路の回帰テストを追加・更新しました。 
- `README.md`にSMTP方式の説明、対応OS、必要な環境変数、STARTTLS/SSL/認証なしの設定例、パスワードを`config.json`に保存しない旨を追記しました。 

### Testing

- 実行した自動テスト: `pytest tests/test_mail_sender.py tests/test_paypay_expiration.py tests/test_match_history.py -q` and `pytest -q`, and all tests passed locally. 
- `tests/test_mail_sender.py`はSMTP接続をモックして`starttls`/`ssl`/`none`、認証有無、添付ファイルのファイル名とMIME種別を検証しました and succeeded. 
- 削除系フローの振る舞い（メール失敗時に削除を中止する、手動ダンプはJSONを残す）を含む`tests/test_match_history.py`の追加ケースを実行し成功しました. 
- 変更はローカルでコミット済みですが、環境のネットワーク制限によりリモートへの`push`およびGitHub上のPR作成はブロックされておりその手続きは未完了（接続エラー `CONNECT tunnel failed, response 403`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e5a368648333ae8f8dc3e5ff1a41)