### PR TITLE
Gate LINE messaging behind env flag and isolate notification side-effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,23 @@ export SECRET_KEY='replace-with-a-long-random-secret'
 
 `SECRET_KEY` は Flask の session cookie 署名に使います。`SECRET_KEY` が設定されている場合はその値を使用します。未設定の場合、デフォルトでは起動に失敗します。ローカル開発だけで固定 fallback を使いたい場合は、明示的に `ALLOW_DEV_SECRET_KEY=1` を設定してください。本番環境では必ず環境変数 `SECRET_KEY` に推測困難な値を設定し、`ALLOW_DEV_SECRET_KEY=1` は使わないでください。
 
-LINE Bot Webhook で通知登録を受け付ける場合は、LINE Developers で発行した次の環境変数を設定してください。
+LINE Bot Webhook で通知登録を受け付ける場合は、本番環境だけで `LINE_MESSAGING_ENABLED` を有効化し、LINE Developers で発行した次の環境変数を設定してください。
 
 ```bash
+export LINE_MESSAGING_ENABLED="1"
 export LINE_CHANNEL_SECRET="..."
 export LINE_CHANNEL_ACCESS_TOKEN="..."
 export LINE_BOT_FRIEND_URL="https://lin.ee/xxxxxxx"
 ```
 
+- `LINE_MESSAGING_ENABLED` は `1`、`true`、`on`、`yes` の場合のみ LINE Messaging 機能を有効にします。本番環境だけで有効化してください。
+- `LINE_MESSAGING_ENABLED` が未設定、または上記以外の値の場合、LINE 機能は完全に無効になります。thanks ページの LINE 通知登録 UI、通知登録開始、Webhook 処理、組み合わせ確定時の LINE Push 通知、通知管理レコード作成はいずれも実行されません。
+- 本番環境では `LINE_CHANNEL_SECRET`、`LINE_CHANNEL_ACCESS_TOKEN`、必要に応じて `LINE_BOT_FRIEND_URL` を設定してください。
 - `LINE_CHANNEL_SECRET` は Webhook 署名検証に使います。
 - `LINE_CHANNEL_ACCESS_TOKEN` は reply / push message 送信に使います。
 - `LINE_BOT_FRIEND_URL` は LINE 連携コード画面の「LINEでBotを開く」ボタンに使います。
 - `LINE_BOT_FRIEND_URL` が未設定でもアプリは起動し、画面表示も壊れないようにしています。
+- 開発環境では LINE 関連環境変数を設定しなくても、組み合わせ確定は通常どおり実行できます。
 - 本番では HTTPS の `/line/webhook` を LINE Developers の Webhook URL に設定してください。
 
 ## 🧭 状態管理と Flask session の方針
@@ -244,7 +249,7 @@ admin モードの `/match/edit` には、「スコアが近いペアで組み�
 
 ## 🔔 LINE通知機能（v1.6.0）
 
-v1.6.0 では、参加者登録後の LINE 通知登録、組み合わせ確定時の個人別 LINE Push 通知、LINE 連携成功時の PayPay 支払い案内に対応しています。
+v1.6.0 では、参加者登録後の LINE 通知登録、組み合わせ確定時の個人別 LINE Push 通知、LINE 連携成功時の PayPay 支払い案内に対応しています。`LINE_MESSAGING_ENABLED` が未設定の場合は LINE 機能全体が無効になり、開発環境では LINE 関連環境変数なしで組み合わせ確定できます。
 
 - 参加登録完了後の thanks ページから LINE 通知登録を開始できます。
 - thanks ページでは LINE 通知登録を主導線として、PayPay 支払い案内より上に表示します。

--- a/app.py
+++ b/app.py
@@ -448,6 +448,24 @@ def get_line_notification_subscription(participant_id, session_id):
     ).first()
 
 
+
+def is_line_messaging_enabled():
+    """Return True only when LINE Messaging is explicitly enabled."""
+    return os.environ.get("LINE_MESSAGING_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "on",
+        "yes",
+    }
+
+
+def has_required_line_messaging_config():
+    """Return True when required LINE Messaging API settings are present."""
+    return bool(
+        os.environ.get("LINE_CHANNEL_SECRET")
+        and os.environ.get("LINE_CHANNEL_ACCESS_TOKEN")
+    )
+
 def get_line_notification_status(participant, current_session):
     has_active_line_account = get_active_line_account(participant) is not None
     current_subscription = get_line_notification_subscription(
@@ -582,6 +600,13 @@ def send_match_confirmed_line_notifications(match_session, match_count, matches=
     """Send confirmed-match LINE notifications once per match count and channel."""
     if match_session is None:
         return False
+    if not is_line_messaging_enabled():
+        return False
+    if not has_required_line_messaging_config():
+        app.logger.warning(
+            "LINE Messaging is enabled but required environment variables are missing; skipping notifications"
+        )
+        return False
 
     try:
         existing_notification = MatchNotification.query.filter_by(
@@ -703,13 +728,14 @@ def thanks():
     participant = Participant.query.filter_by(card=card).first() if card else None
     line_notification_status = None
     if participant is not None:
-        if participant.active:
-            current_session = ensure_current_match_session()
-            line_notification_status = get_line_notification_status(
-                participant, current_session
-            )
-        else:
-            line_notification_status = {"state": "inactive"}
+        if is_line_messaging_enabled():
+            if participant.active:
+                current_session = ensure_current_match_session()
+                line_notification_status = get_line_notification_status(
+                    participant, current_session
+                )
+            else:
+                line_notification_status = {"state": "inactive"}
     return render_template(
         'thanks.html',
         paypay_links=paypay_links,
@@ -891,6 +917,9 @@ def process_line_webhook_event(event):
 
 @app.route('/line/webhook', methods=['POST'])
 def line_webhook():
+    if not is_line_messaging_enabled():
+        return jsonify({"status": "disabled", "message": "LINE Messaging is disabled"}), 200
+
     raw_body = request.get_data()
     signature = request.headers.get("X-Line-Signature")
     channel_secret = os.environ.get("LINE_CHANNEL_SECRET")
@@ -906,6 +935,9 @@ def line_webhook():
 def start_line_notification(card):
     mode = request.args.get('mode', 'viewer')
     participant = get_participant_by_card_or_404(card)
+    if not is_line_messaging_enabled():
+        flash("LINE通知は現在無効です", "info")
+        return redirect(url_for('thanks', mode=mode, card=participant.card))
     if not participant.active:
         flash("現在参加中の方のみLINE通知登録できます", "info")
         return redirect(url_for('thanks', mode=mode, card=participant.card))
@@ -1395,12 +1427,20 @@ def confirm_match():
         current_session.status = "confirmed"
         if current_session.confirmed_at is None:
             current_session.confirmed_at = utc_now()
-        send_match_confirmed_line_notifications(current_session, match_count, match_ids, bench_ids)
 
         db.session.commit()
     except Exception:
         db.session.rollback()
         raise
+
+    try:
+        send_match_confirmed_line_notifications(current_session, match_count, match_ids, bench_ids)
+    except Exception:
+        app.logger.exception(
+            "Unexpected error while sending LINE match notifications: session_id=%s match_count=%s",
+            current_session.id,
+            match_count,
+        )
 
     mode = request.form.get('mode', 'viewer')
     return redirect(url_for('match_result', mode=mode))

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -10,6 +10,9 @@ import pytest
 
 
 def load_test_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("LINE_MESSAGING_ENABLED", "1")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "test-access-token")
     (tmp_path / "config.json").write_text(
         json.dumps(
             {
@@ -693,3 +696,38 @@ def test_line_webhook_success_with_one_paypay_link_includes_available_link(
         assert "社会人の方はこちら（600円）\nhttps://example.com/pay/adults" in reply_text
         assert "学生の方はこちら（300円）" not in reply_text
         assert "PayPayリンクが未設定" not in reply_text
+
+
+def test_thanks_page_hides_line_notification_ui_when_line_disabled(app_module, participant, monkeypatch):
+    monkeypatch.delenv("LINE_MESSAGING_ENABLED", raising=False)
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        html = client.get("/thanks?card=C1").get_data(as_text=True)
+
+        assert "🔔 LINE通知" not in html
+        assert "LINE通知を登録する" not in html
+        assert "📱 PayPay" in html
+
+
+def test_start_line_notification_redirects_safely_when_line_disabled(app_module, participant, monkeypatch):
+    monkeypatch.delenv("LINE_MESSAGING_ENABLED", raising=False)
+    client = app_module.app.test_client()
+
+    with app_module.app.app_context():
+        response = client.get("/notifications/line/start/C1", follow_redirects=True)
+
+        assert response.status_code == 200
+        assert "LINE通知は現在無効です" in response.get_data(as_text=True)
+        assert app_module.LineLinkToken.query.count() == 0
+        assert app_module.NotificationSubscription.query.count() == 0
+
+
+def test_line_webhook_returns_disabled_response_when_line_disabled(app_module, monkeypatch):
+    monkeypatch.delenv("LINE_MESSAGING_ENABLED", raising=False)
+    client = app_module.app.test_client()
+
+    response = client.post("/line/webhook", json={"events": []})
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "disabled"

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -12,6 +12,9 @@ from utils.match_session import get_current_match_session, get_current_session_i
 
 
 def load_history_test_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("LINE_MESSAGING_ENABLED", "1")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-line-secret")
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "test-access-token")
     config = {"level_map": {}, "gender_weight": {}}
     (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
     monkeypatch.chdir(tmp_path)
@@ -2041,7 +2044,31 @@ def test_confirm_match_completes_match_notification_with_zero_targets(monkeypatc
         assert notification.sent_at is not None
 
 
-def test_confirm_match_without_line_token_creates_failed_log(monkeypatch, tmp_path):
+def test_confirm_match_line_disabled_skips_notifications_and_still_confirms(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+    monkeypatch.delenv("LINE_MESSAGING_ENABLED", raising=False)
+    monkeypatch.setattr(
+        app_module,
+        "push_line_message",
+        lambda user_id, text: pytest.fail("unexpected LINE push"),
+    )
+
+    with app_module.app.app_context():
+        participants, current_session, _ = prepare_confirm_with_session(app_module, tmp_path)
+        add_line_subscription(app_module, current_session.id, participants[0], user_id="U-current")
+        app_module.db.session.commit()
+
+        response = app_module.app.test_client().post("/match/confirm")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.NotificationDeliveryLog.query.count() == 0
+        assert app_module.MatchNotification.query.count() == 0
+        assert app_module.load_match_state()["match_count"] == 1
+
+
+def test_confirm_match_line_enabled_without_token_skips_notification_records(monkeypatch, tmp_path, caplog):
     app_module = load_history_test_app(monkeypatch, tmp_path)
     monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
 
@@ -2053,13 +2080,29 @@ def test_confirm_match_without_line_token_creates_failed_log(monkeypatch, tmp_pa
         response = app_module.app.test_client().post("/match/confirm")
 
         assert response.status_code == 302
-        log = app_module.NotificationDeliveryLog.query.one()
-        assert log.match_count == 1
-        assert log.status == "failed"
-        assert "LINE_CHANNEL_ACCESS_TOKEN is not set" in log.error_message
-        notification = app_module.MatchNotification.query.one()
-        assert notification.status == "completed"
-        assert notification.sent_at is not None
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.NotificationDeliveryLog.query.count() == 0
+        assert app_module.MatchNotification.query.count() == 0
+        assert "required environment variables are missing" in caplog.text
+
+
+def test_confirm_match_notification_exception_does_not_rollback_confirmation(monkeypatch, tmp_path):
+    app_module = load_history_test_app(monkeypatch, tmp_path)
+
+    def fail_notification(*args, **kwargs):
+        raise RuntimeError("unexpected notification failure")
+
+    monkeypatch.setattr(app_module, "send_match_confirmed_line_notifications", fail_notification)
+
+    with app_module.app.app_context():
+        prepare_confirm_with_session(app_module, tmp_path)
+
+        response = app_module.app.test_client().post("/match/confirm")
+
+        assert response.status_code == 302
+        assert app_module.MatchRound.query.count() == 1
+        assert app_module.MatchHistory.query.count() == 1
+        assert app_module.load_match_state()["match_count"] == 1
 
 
 def set_history_dump_email_config(tmp_path, enabled=True, recipient="dump@example.com"):


### PR DESCRIPTION
### Motivation
- Prevent LINE notifications from running in local/non-production environments and avoid failed delivery noise when `LINE_CHANNEL_ACCESS_TOKEN` is not present. 
- Ensure unexpected LINE-related errors do not break or roll back match confirmation transactions. 
- Hide LINE registration UI and make webhook/registration routes safe when LINE messaging is disabled. 

### Description
- Add `LINE_MESSAGING_ENABLED` feature flag with a truthy check for values `1`, `true`, `on`, `yes` and helper `is_line_messaging_enabled()`; add `has_required_line_messaging_config()` to require `LINE_CHANNEL_SECRET` and `LINE_CHANNEL_ACCESS_TOKEN` before sending notifications. 
- Short-circuit notification side effects when the flag is disabled or required env vars are missing so no `MatchNotification` / `NotificationDeliveryLog` records are created and no LINE API calls are made. 
- Commit match confirmation DB state first and run `send_match_confirmed_line_notifications()` after commit inside a separate `try/except` so notification exceptions only log and do not rollback the confirmation. 
- Hide the LINE notification section on the `thanks` page unless the feature flag is enabled, make `/notifications/line/start/<card>` flash-and-redirect when LINE is disabled, and make `/line/webhook` return a clear disabled JSON response. 
- Update documentation in `README.md` about `LINE_MESSAGING_ENABLED` and required production env vars. 
- Update/extend tests in `tests/test_line_notification_routes.py` and `tests/test_match_history.py` to explicitly enable LINE in test setup where needed and add tests to cover disabled-flag behavior, missing-config behavior, and notification-exception isolation. 

### Testing
- Ran the full test suite with `pytest -q` and it completed successfully. 
- Added/updated focused tests that were executed: new/modified assertions in `tests/test_line_notification_routes.py` and `tests/test_match_history.py` covering disabled UI/webhook, safe redirects when disabled, skipping notification records when config is missing, and ensuring notification failures do not rollback confirmations. 
- All tests (including the modified LINE-related tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f371669c8333817a96f85b813266)