### PR TITLE
Move thanks page LINE notification below payment completion button

### DIFF
--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -86,29 +86,6 @@
 
 <h1>登録完了</h1>
 
-{% if participant and line_notification_status %}
-<div class="line-notification">
-    <h3>🔔 LINE通知</h3>
-    {% if line_notification_status.state == 'inactive' %}
-        <p>現在参加中の方のみLINE通知登録できます。</p>
-    {% elif line_notification_status.state == 'unlinked' %}
-        <p><strong>まずLINE通知登録をお願いします。</strong></p>
-        <p>組み合わせ確定通知と支払いリンクをLINEで受け取れます。</p>
-        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE通知を登録する</a>
-    {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}
-        <p><strong>LINE連携済みです。</strong></p>
-        <p>今回の組み合わせ通知を受け取るには通知登録してください。通知登録後、LINE上で支払いリンクも案内されます。</p>
-        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">今回のLINE通知を受け取る</a>
-    {% elif line_notification_status.state == 'subscribed' %}
-        <p>LINE通知登録済みです。</p>
-        <p>組み合わせ確定通知と支払いリンクはLINEでも案内されます。</p>
-        <form method="post" action="{{ url_for('unsubscribe_line_notification', card=participant.card) }}">
-            <input type="hidden" name="mode" value="{{ mode }}">
-            <button type="submit" class="btn btn-secondary btn-block unsubscribe-button">LINE通知を解除する</button>
-        </form>
-    {% endif %}
-</div>
-{% endif %}
 
 <section class="payment-guidance">
 <h3>参加費</h3>
@@ -139,6 +116,30 @@
     <a href="{{ url_for('admin_index') }}" class="btn btn-secondary btn-block">支払い完了 → トップに戻る</a>
 {% else %}
     <a href="{{ url_for('viewer_index') }}" class="btn btn-secondary btn-block">支払い完了 → トップに戻る</a>
+{% endif %}
+
+{% if participant and line_notification_status %}
+<div class="line-notification">
+    <h3>🔔 LINE通知</h3>
+    {% if line_notification_status.state == 'inactive' %}
+        <p>現在参加中の方のみLINE通知登録できます。</p>
+    {% elif line_notification_status.state == 'unlinked' %}
+        <p><strong>まずLINE通知登録をお願いします。</strong></p>
+        <p>組み合わせ確定通知と支払いリンクをLINEで受け取れます。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">LINE通知を登録する</a>
+    {% elif line_notification_status.state in ['linked_unsubscribed', 'linked_past_session_only'] %}
+        <p><strong>LINE連携済みです。</strong></p>
+        <p>今回の組み合わせ通知を受け取るには通知登録してください。通知登録後、LINE上で支払いリンクも案内されます。</p>
+        <a href="{{ url_for('start_line_notification', card=participant.card, mode=mode) }}" class="btn btn-primary btn-block line-button">今回のLINE通知を受け取る</a>
+    {% elif line_notification_status.state == 'subscribed' %}
+        <p>LINE通知登録済みです。</p>
+        <p>組み合わせ確定通知と支払いリンクはLINEでも案内されます。</p>
+        <form method="post" action="{{ url_for('unsubscribe_line_notification', card=participant.card) }}">
+            <input type="hidden" name="mode" value="{{ mode }}">
+            <button type="submit" class="btn btn-secondary btn-block unsubscribe-button">LINE通知を解除する</button>
+        </form>
+    {% endif %}
+</div>
 {% endif %}
 
 <p style="color: gray;">現在のモード: {{ mode }}</p>

--- a/tests/test_line_notification_routes.py
+++ b/tests/test_line_notification_routes.py
@@ -249,10 +249,12 @@ def test_thanks_page_line_notification_display_branches(app_module, participant)
         assert "まずLINE通知登録をお願いします" in unlinked_html
         assert "組み合わせ確定通知と支払いリンクをLINEで受け取れます" in unlinked_html
         assert "LINE通知を登録する" in unlinked_html
-        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("📱 PayPay")
-        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("社会人：600円")
-        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("学生：300円")
         assert unlinked_html.index("📱 PayPay") > unlinked_html.index("参加費")
+        assert unlinked_html.index("支払い完了 → トップに戻る") < unlinked_html.index("🔔 LINE通知")
+        assert unlinked_html.index("🔔 LINE通知") > unlinked_html.index("📱 PayPay")
+        assert unlinked_html.index("🔔 LINE通知") > unlinked_html.index("社会人：600円")
+        assert unlinked_html.index("🔔 LINE通知") > unlinked_html.index("学生：300円")
+        assert unlinked_html.index("🔔 LINE通知") < unlinked_html.index("現在のモード")
         assert "LINEを使わない場合、または先に支払う場合はこちら" in unlinked_html
 
         add_line_account(app_module, participant)


### PR DESCRIPTION
### Motivation
- Reorder the thanks page so the LINE notification UI appears immediately after the "支払い完了 → トップに戻る" button to match the requested display flow while keeping existing behavior unchanged.

### Description
- Moved the LINE notification block in `templates/thanks.html` to directly follow the payment-completion button and before the current mode display.
- Preserved all existing LINE state branches and logic (`inactive`, `unlinked`, `linked_unsubscribed`/`linked_past_session_only`, and `subscribed`) and left PayPay/payment guidance logic unchanged.
- Updated the display-order assertions in `tests/test_line_notification_routes.py` to assert that the payment button precedes the LINE notification section and the LINE section precedes the current-mode text.
- Modified files: `templates/thanks.html`, `tests/test_line_notification_routes.py`.

### Testing
- Ran `pytest` and all tests passed (`285 passed`).
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61b59cff78833384d25ee69d553482)