### PR TITLE
参加者向けマニュアルを追加

### DIFF
--- a/manual-site/app/globals.css
+++ b/manual-site/app/globals.css
@@ -428,6 +428,386 @@ h1 {
   color: var(--navy-900);
 }
 
+.participant-hero {
+  margin-bottom: 30px;
+}
+
+.page-toc {
+  margin-bottom: 54px;
+  padding: 18px 20px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface-soft);
+}
+
+.page-toc p {
+  margin-bottom: 10px;
+  color: var(--navy-950);
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.page-toc div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.page-toc a {
+  padding: 7px 13px;
+  border: 1px solid #cbdce9;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--navy-900);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.page-toc a:hover {
+  border-color: #77c9e4;
+  background: var(--cyan-100);
+}
+
+.manual-section {
+  scroll-margin-top: 112px;
+  margin-top: 64px;
+  padding-top: 2px;
+}
+
+.manual-section + .manual-section {
+  padding-top: 58px;
+  border-top: 1px solid var(--line);
+}
+
+.manual-section-heading {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.manual-step-number {
+  display: grid;
+  flex: 0 0 56px;
+  width: 56px;
+  height: 56px;
+  place-items: center;
+  border-radius: 16px;
+  background: var(--navy-900);
+  color: #fff;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.section-kicker {
+  margin-bottom: 1px;
+  color: var(--blue-600);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.manual-section-heading h2 {
+  margin-bottom: 0;
+  color: var(--navy-950);
+  font-size: clamp(24px, 3vw, 32px);
+  line-height: 1.4;
+}
+
+.section-intro {
+  max-width: 800px;
+  margin-bottom: 26px;
+  color: #415067;
+  font-size: 17px;
+}
+
+.instruction-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(300px, 0.92fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.instruction-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: instruction;
+}
+
+.instruction-list li {
+  position: relative;
+  display: grid;
+  gap: 3px;
+  min-height: 86px;
+  padding: 9px 8px 20px 60px;
+  counter-increment: instruction;
+}
+
+.instruction-list li::before {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  display: grid;
+  width: 39px;
+  height: 39px;
+  place-items: center;
+  border: 2px solid #8dd5e9;
+  border-radius: 50%;
+  background: #f4fcfe;
+  color: var(--navy-900);
+  content: counter(instruction);
+  font-weight: 800;
+}
+
+.instruction-list li:not(:last-child)::after {
+  position: absolute;
+  top: 45px;
+  bottom: 0;
+  left: 19px;
+  width: 1px;
+  background: #b9dfe9;
+  content: "";
+}
+
+.instruction-list strong {
+  color: var(--navy-950);
+  font-size: 17px;
+}
+
+.instruction-list span {
+  color: var(--muted);
+}
+
+.instruction-list.single-column {
+  max-width: 760px;
+}
+
+.card-choice-note {
+  padding: 24px;
+  border: 1px solid #b7dce8;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #f5fdff, #f9fbfd);
+  box-shadow: 0 10px 28px rgb(7 29 73 / 5%);
+}
+
+.callout-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  color: var(--navy-900);
+  font-size: 18px;
+}
+
+.card-choice-note > p {
+  margin-bottom: 18px;
+  color: #526077;
+}
+
+.suit-guide {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.suit-guide > div {
+  display: grid;
+  gap: 2px;
+  padding: 16px 12px;
+  border: 1px solid #d9e3ec;
+  border-radius: 12px;
+  background: #fff;
+  text-align: center;
+}
+
+.suit-symbol {
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.red-suit {
+  color: #cf2f43;
+}
+
+.black-suit {
+  color: #17213a;
+}
+
+.suit-guide strong {
+  color: var(--navy-950);
+  font-size: 15px;
+}
+
+.suit-guide small {
+  color: var(--muted);
+}
+
+.card-choice-note .callout-footnote {
+  margin: 16px 0 0;
+  font-size: 13px;
+}
+
+.attention-note {
+  margin-top: 24px;
+  padding: 18px 20px;
+  border-left: 4px solid #efa932;
+  border-radius: 4px 12px 12px 4px;
+  background: #fff9ec;
+}
+
+.attention-note strong {
+  color: #714800;
+}
+
+.attention-note p {
+  margin: 3px 0 0;
+  color: #655533;
+}
+
+.state-cards,
+.payment-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.state-cards article {
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.state-check,
+.state-pause {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  margin-bottom: 14px;
+  place-items: center;
+  border-radius: 10px;
+  font-size: 20px;
+  font-weight: 850;
+}
+
+.state-check {
+  background: #e5f7ed;
+  color: #16834a;
+}
+
+.state-pause {
+  background: #eef2f6;
+  color: #59697c;
+}
+
+.state-cards h3,
+.payment-options h3 {
+  margin-bottom: 5px;
+  color: var(--navy-950);
+  font-size: 18px;
+}
+
+.state-cards p,
+.payment-options p {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.tip-note {
+  display: flex;
+  gap: 12px;
+  margin-top: 22px;
+  padding: 17px 19px;
+  border-radius: 12px;
+  background: var(--cyan-100);
+  color: var(--navy-900);
+}
+
+.tip-note svg {
+  flex: 0 0 auto;
+  margin-top: 3px;
+}
+
+.tip-note p,
+.muted-note {
+  margin-bottom: 0;
+}
+
+.payment-options article {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.payment-options article > span {
+  font-size: 30px;
+  line-height: 1.25;
+}
+
+.muted-note {
+  margin-top: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.compact-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compact-steps li {
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--surface);
+}
+
+.compact-steps span {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  margin-bottom: 12px;
+  place-items: center;
+  border-radius: 50%;
+  background: #06c755;
+  color: #fff;
+  font-weight: 800;
+}
+
+.compact-steps p {
+  margin-bottom: 0;
+  color: #445268;
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.65;
+}
+
+.line-note {
+  border-left-color: #06c755;
+  background: #effcf4;
+}
+
+.line-note strong {
+  color: #075b2b;
+}
+
+.line-note p {
+  color: #315d43;
+}
+
 .search-overlay {
   position: fixed;
   z-index: 80;
@@ -546,6 +926,18 @@ h1 {
     width: 42px;
     height: 42px;
   }
+
+  .instruction-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-choice-note {
+    max-width: 680px;
+  }
+
+  .compact-steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 780px) {
@@ -617,7 +1009,9 @@ h1 {
   }
 
   .audience-grid,
-  .topic-grid {
+  .topic-grid,
+  .state-cards,
+  .payment-options {
     grid-template-columns: 1fr;
   }
 
@@ -628,6 +1022,10 @@ h1 {
 
   .audience-card {
     min-height: 170px;
+  }
+
+  .manual-section {
+    scroll-margin-top: 92px;
   }
 }
 
@@ -673,6 +1071,59 @@ h1 {
 
   .topic-card {
     padding: 22px;
+  }
+
+  .page-toc {
+    padding: 16px;
+  }
+
+  .manual-section {
+    margin-top: 50px;
+  }
+
+  .manual-section + .manual-section {
+    padding-top: 46px;
+  }
+
+  .manual-section-heading {
+    align-items: flex-start;
+    gap: 13px;
+  }
+
+  .manual-step-number {
+    flex-basis: 46px;
+    width: 46px;
+    height: 46px;
+    border-radius: 13px;
+    font-size: 15px;
+  }
+
+  .manual-section-heading h2 {
+    font-size: 24px;
+  }
+
+  .suit-guide,
+  .compact-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .instruction-list li {
+    padding-right: 0;
+    padding-left: 52px;
+  }
+
+  .instruction-list li::before {
+    width: 35px;
+    height: 35px;
+  }
+
+  .instruction-list li:not(:last-child)::after {
+    top: 41px;
+    left: 17px;
+  }
+
+  .card-choice-note {
+    padding: 20px;
   }
 
   .search-overlay {

--- a/manual-site/app/manual-data.ts
+++ b/manual-site/app/manual-data.ts
@@ -22,14 +22,26 @@ export const searchItems = [
   {
     href: "/participant#registration",
     title: "参加登録",
-    description: "名前・性別・レベルを登録する",
-    keywords: "参加者 新規 登録",
+    description: "空いているカードを選び、名前・性別・レベルを登録する",
+    keywords: "参加者 新規 登録 カード 赤 黒 ハート ダイヤ クラブ スペード",
+  },
+  {
+    href: "/participant#participation",
+    title: "参加・休憩・早退を切り替える",
+    description: "ゲーム参加中のチェックを変更する",
+    keywords: "参加者 休憩 早退 再開 active",
+  },
+  {
+    href: "/participant#payment",
+    title: "参加費を支払う",
+    description: "現金またはPayPayで参加費を支払う",
+    keywords: "参加者 支払い 参加費 現金 PayPay 社会人 学生",
   },
   {
     href: "/participant#card-and-match",
-    title: "カードと組み合わせの確認",
-    description: "自分のカード、コート、ペアを確認する",
-    keywords: "カード コート 試合 対戦",
+    title: "現在の組み合わせを確認する",
+    description: "自分のコート、ペア、対戦相手、待機を確認する",
+    keywords: "カード コート 試合 対戦 ペア 待機 ベンチ 更新",
   },
   {
     href: "/participant#line-notification",

--- a/manual-site/app/participant/page.tsx
+++ b/manual-site/app/participant/page.tsx
@@ -1,44 +1,224 @@
 import type { Metadata } from "next";
-import { SectionPage } from "../components/section-page";
+import { Icon } from "../components/icon";
+import { ManualShell } from "../components/manual-shell";
 
 export const metadata: Metadata = { title: "参加者向け" };
 
+const quickLinks = [
+  { href: "#registration", label: "初回登録" },
+  { href: "#participation", label: "参加・休憩" },
+  { href: "#payment", label: "参加費" },
+  { href: "#line-notification", label: "LINE通知" },
+  { href: "#card-and-match", label: "組み合わせ" },
+];
+
 export default function ParticipantPage() {
   return (
-    <SectionPage
-      eyebrow="FOR PARTICIPANTS"
-      lead="練習への参加登録から、自分のカードと組み合わせの確認、LINE通知の受け取り方までを案内します。"
-      title="参加者向け"
-      topics={[
-        {
-          id: "registration",
-          icon: "user",
-          title: "参加登録",
-          description:
-            "名前・性別・競技レベルを入力し、当日の参加者として登録します。",
-        },
-        {
-          id: "card-and-match",
-          icon: "card",
-          title: "カードと組み合わせ",
-          description:
-            "割り当てられたカードから、自分のコート・ペア・対戦相手を確認します。",
-        },
-        {
-          id: "line-notification",
-          icon: "bell",
-          title: "LINE通知を受け取る",
-          description:
-            "LINEアカウントを連携し、組み合わせ確定時の通知を登録します。",
-        },
-        {
-          id: "result",
-          icon: "history",
-          title: "結果を確認する",
-          description:
-            "確定した最新の組み合わせと、入力済みの試合結果を確認します。",
-        },
-      ]}
-    />
+    <ManualShell>
+      <section className="hero participant-hero">
+        <p className="eyebrow">FOR PARTICIPANTS</p>
+        <h1>参加者向け</h1>
+        <p className="lead">
+          最初に自分のカードを登録したら、同じカードから参加状態や組み合わせを確認できます。
+          当日の流れに沿って操作を案内します。
+        </p>
+      </section>
+
+      <nav className="page-toc" aria-label="参加者向けページ内メニュー">
+        <p>知りたい項目へ</p>
+        <div>
+          {quickLinks.map((item) => (
+            <a href={item.href} key={item.href}>
+              {item.label}
+            </a>
+          ))}
+        </div>
+      </nav>
+
+      <section className="manual-section" id="registration">
+        <div className="manual-section-heading">
+          <span className="manual-step-number">01</span>
+          <div>
+            <p className="section-kicker">初めて使うとき</p>
+            <h2>空いているカードを選んで参加登録する</h2>
+          </div>
+        </div>
+
+        <div className="instruction-grid">
+          <ol className="instruction-list">
+            <li>
+              <strong>参加者一覧を開く</strong>
+              <span>ハート・ダイヤ・クラブ・スペードのカードが並んでいます。</span>
+            </li>
+            <li>
+              <strong>名前が入っていないカードをタップ</strong>
+              <span>空いているカードの中から、好きなものを1枚選びます。</span>
+            </li>
+            <li>
+              <strong>名前・性別・競技レベルを入力</strong>
+              <span>競技レベルは「初級・中級・上級」から選びます。</span>
+            </li>
+            <li>
+              <strong>「登録」をタップ</strong>
+              <span>登録が終わると、参加費とLINE通知の案内が表示されます。</span>
+            </li>
+          </ol>
+
+          <aside className="card-choice-note" aria-label="カード選びのおすすめ">
+            <div className="callout-title">
+              <Icon name="card" size={25} />
+              <strong>カードは自由に選べます</strong>
+            </div>
+            <p>
+              選ぶカードに決まりはありません。会場で見分けやすくしたい場合は、次の分け方がおすすめです。
+            </p>
+            <div className="suit-guide">
+              <div>
+                <span className="suit-symbol red-suit">♥ ♦</span>
+                <strong>赤のカード</strong>
+                <small>女性におすすめ</small>
+              </div>
+              <div>
+                <span className="suit-symbol black-suit">♣ ♠</span>
+                <strong>黒のカード</strong>
+                <small>男性におすすめ</small>
+              </div>
+            </div>
+            <p className="callout-footnote">
+              ※ 色分けは必須ではありません。ジョーカーも空いていれば選べます。
+            </p>
+          </aside>
+        </div>
+
+        <div className="attention-note">
+          <strong>カードにすでに名前がある場合</strong>
+          <p>
+            そのカードは登録済みです。初回登録では、名前が入っていない別のカードを選んでください。
+          </p>
+        </div>
+      </section>
+
+      <section className="manual-section" id="participation">
+        <div className="manual-section-heading">
+          <span className="manual-step-number">02</span>
+          <div>
+            <p className="section-kicker">登録したあと</p>
+            <h2>参加・休憩・早退を切り替える</h2>
+          </div>
+        </div>
+
+        <p className="section-intro">
+          参加者一覧で自分のカードをタップすると、登録情報を変更できます。
+        </p>
+        <div className="state-cards">
+          <article>
+            <span className="state-check" aria-hidden="true">✓</span>
+            <h3>ゲームに参加するとき</h3>
+            <p>「ゲーム参加中」にチェックを入れて「更新」をタップします。</p>
+          </article>
+          <article>
+            <span className="state-pause" aria-hidden="true">—</span>
+            <h3>休憩・早退するとき</h3>
+            <p>「ゲーム参加中」のチェックを外して「更新」をタップします。</p>
+          </article>
+        </div>
+        <div className="tip-note">
+          <Icon name="spark" size={23} />
+          <p>
+            休憩から戻るときは、同じ画面でチェックを入れ直してください。名前・性別・競技レベルもここから変更できます。
+          </p>
+        </div>
+      </section>
+
+      <section className="manual-section" id="payment">
+        <div className="manual-section-heading">
+          <span className="manual-step-number">03</span>
+          <div>
+            <p className="section-kicker">登録完了後</p>
+            <h2>参加費を支払う</h2>
+          </div>
+        </div>
+
+        <p className="section-intro">
+          登録完了画面で、当日の案内に従って現金またはPayPayで支払います。
+        </p>
+        <div className="payment-options">
+          <article>
+            <span aria-hidden="true">💰</span>
+            <div>
+              <h3>現金</h3>
+              <p>参加費を会場のかごに入れます。</p>
+            </div>
+          </article>
+          <article>
+            <span aria-hidden="true">📱</span>
+            <div>
+              <h3>PayPay</h3>
+              <p>社会人・学生の該当する支払いボタンをタップします。</p>
+            </div>
+          </article>
+        </div>
+        <p className="muted-note">
+          支払いが終わったら「支払い完了 → トップに戻る」をタップします。参加費は開催時の画面表示を確認してください。
+        </p>
+      </section>
+
+      <section className="manual-section" id="line-notification">
+        <div className="manual-section-heading">
+          <span className="manual-step-number">04</span>
+          <div>
+            <p className="section-kicker">任意</p>
+            <h2>LINEで組み合わせ通知を受け取る</h2>
+          </div>
+        </div>
+
+        <p className="section-intro">
+          LINE通知を登録すると、組み合わせが確定したときに自分のコート・ペア・対戦相手、または待機をLINEで確認できます。
+        </p>
+        <ol className="compact-steps">
+          <li><span>1</span><p>登録完了画面で「LINE通知を登録する」をタップ</p></li>
+          <li><span>2</span><p>表示された連携コードをタップしてコピー</p></li>
+          <li><span>3</span><p>「LINEでBotを開く」からトーク画面を開く</p></li>
+          <li><span>4</span><p>コピーしたコードを貼り付けて送信</p></li>
+        </ol>
+        <div className="attention-note line-note">
+          <strong>次回参加時も確認してください</strong>
+          <p>
+            LINEアカウントの連携後も、当日分の通知登録が必要な場合があります。登録完了画面に「今回のLINE通知を受け取る」が表示されたらタップしてください。
+          </p>
+        </div>
+      </section>
+
+      <section className="manual-section" id="card-and-match">
+        <div className="manual-section-heading">
+          <span className="manual-step-number">05</span>
+          <div>
+            <p className="section-kicker">組み合わせ確定後</p>
+            <h2>自分のコートと組み合わせを確認する</h2>
+          </div>
+        </div>
+
+        <ol className="instruction-list single-column">
+          <li>
+            <strong>参加者一覧を更新する</strong>
+            <span>「表示を更新」をタップして最新の状態にします。</span>
+          </li>
+          <li>
+            <strong>「現在の組み合わせを表示」をタップ</strong>
+            <span>組み合わせが確定しているときだけボタンが表示されます。</span>
+          </li>
+          <li>
+            <strong>自分のカードを探す</strong>
+            <span>コート番号、ペア、対戦相手を確認します。待機の場合は待機者欄に表示されます。</span>
+          </li>
+        </ol>
+        <div className="tip-note">
+          <Icon name="bell" size={23} />
+          <p>
+            LINE通知を登録している場合は、組み合わせ確定時に同じ内容が届きます。表示が古いときは、ページを更新してください。
+          </p>
+        </div>
+      </section>
+    </ManualShell>
   );
 }

--- a/manual-site/tests/browser-interactions.test.mjs
+++ b/manual-site/tests/browser-interactions.test.mjs
@@ -252,3 +252,26 @@ test("keeps every search result reachable in a short mobile viewport", async () 
   assert.ok(resultBox.y + resultBox.height <= 375);
   assert.ok(dialogBox.y + dialogBox.height <= 375);
 });
+
+test("keeps the participant guide usable on a narrow viewport", async () => {
+  const browser = await launchBrowser();
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.goto(`${baseUrl}/participant`);
+
+  assert.equal(
+    await page.locator("html").evaluate((element) =>
+      element.scrollWidth <= element.clientWidth,
+    ),
+    true,
+  );
+
+  await page.getByRole("link", { name: "LINE通知", exact: true }).last().click();
+  await page.waitForURL(`${baseUrl}/participant#line-notification`);
+  assert.equal(new URL(page.url()).hash, "#line-notification");
+  assert.equal(
+    await page
+      .getByRole("heading", { name: "LINEで組み合わせ通知を受け取る" })
+      .isVisible(),
+    true,
+  );
+});

--- a/manual-site/tests/rendered-html.test.mjs
+++ b/manual-site/tests/rendered-html.test.mjs
@@ -65,3 +65,35 @@ test("renders every manual section", async () => {
     assert.match(await response.text(), new RegExp(expectedText), path);
   }
 });
+
+test("renders the participant workflow and card choice guidance", async () => {
+  const workerUrl = new URL("../dist/server/index.js", import.meta.url);
+  workerUrl.searchParams.set("participant", `${process.pid}-${Date.now()}`);
+  const { default: worker } = await import(workerUrl.href);
+
+  const response = await worker.fetch(
+    new Request("http://localhost/participant", {
+      headers: { accept: "text/html" },
+    }),
+    {
+      ASSETS: {
+        fetch: async () => new Response("Not found", { status: 404 }),
+      },
+    },
+    {
+      waitUntil() {},
+      passThroughOnException() {},
+    },
+  );
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.match(html, /空いているカードを選んで参加登録する/);
+  assert.match(html, /カードは自由に選べます/);
+  assert.match(html, /女性におすすめ/);
+  assert.match(html, /男性におすすめ/);
+  assert.match(html, /参加・休憩・早退を切り替える/);
+  assert.match(html, /LINEで組み合わせ通知を受け取る/);
+  assert.match(html, /自分のコートと組み合わせを確認する/);
+  assert.doesNotMatch(html, /基盤作成中/);
+});


### PR DESCRIPTION
## 変更内容

- 参加者向けページを、当日の操作順に沿った5段階のガイドへ更新
- 空いているカードを自由に選ぶ運用と、女性は赤・男性は黒という任意のおすすめを明記
- 参加・休憩・早退、参加費、LINE通知、組み合わせ確認の手順を追加
- ページ内メニューと検索項目を拡充
- PC・スマートフォン向けのレスポンシブ表示を追加

## 影響

参加者が初回登録から組み合わせ確認までを、実際の画面文言に沿って確認できます。アプリ本体の動作には変更ありません。

## 確認

- `npm run lint`
- `npm test`（8件）
- `git diff --check`
- PC表示の実画面確認
- 幅390pxで横スクロールが発生せず、ページ内リンクが利用できることをブラウザテストで確認